### PR TITLE
Migrate to CodeCov.io

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,5 +43,5 @@ jobs:
       - run:
           name: "Generate and Upload Code Coverage"
           command: |
-            bundle exec slather
-            bash <(curl -s https://codecov.io/bash) -f path/to/xml_report/cobertura.xml -X coveragepy -X gcov -X xcode
+            slather
+            bash <(curl -s https://codecov.io/bash) -f ./cobertura.xml -X coveragepy -X gcov -X xcode

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             brew install xcodegen swiftlint carthage swift-protobuf grpc-swift
             brew upgrade
             npm i -g grpc-tools
-#            sudo gem install slather
+           sudo gem install slather
 
       - run:
           name: "Pull Submodules"
@@ -40,6 +40,8 @@ jobs:
           name: "Build and Test"
           command: set -o pipefail && xcodebuild test -scheme XpringKit_iOS -destination 'platform=iOS Simulator,name=iPhone X,OS=12.2' ONLY_ACTIVE_ARCH=YES | xcpretty
 
-#      - run:
-#          name: "Generate and Upload Code Coverage"
-#          command: slather
+     - run:
+          name: "Generate and Upload Code Coverage"
+          command: |
+            bundle exec slather
+            bash <(curl -s https://codecov.io/bash) -f path/to/xml_report/cobertura.xml -X coveragepy -X gcov -X xcode

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             brew install xcodegen swiftlint carthage swift-protobuf grpc-swift
             brew upgrade
             npm i -g grpc-tools
-           sudo gem install slather
+            sudo gem install slather
 
       - run:
           name: "Pull Submodules"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
           name: "Build and Test"
           command: set -o pipefail && xcodebuild test -scheme XpringKit_iOS -destination 'platform=iOS Simulator,name=iPhone X,OS=12.2' ONLY_ACTIVE_ARCH=YES | xcpretty
 
-     - run:
+      - run:
           name: "Generate and Upload Code Coverage"
           command: |
             bundle exec slather

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             brew install xcodegen swiftlint carthage swift-protobuf grpc-swift
             brew upgrade
             npm i -g grpc-tools
-            sudo gem install slather
+#            sudo gem install slather
 
       - run:
           name: "Pull Submodules"
@@ -40,6 +40,6 @@ jobs:
           name: "Build and Test"
           command: set -o pipefail && xcodebuild test -scheme XpringKit_iOS -destination 'platform=iOS Simulator,name=iPhone X,OS=12.2' ONLY_ACTIVE_ARCH=YES | xcpretty
 
-      - run:
-          name: "Generate and Upload Code Coverage"
-          command: slather
+#      - run:
+#          name: "Generate and Upload Code Coverage"
+#          command: slather

--- a/.slather.yml
+++ b/.slather.yml
@@ -1,5 +1,5 @@
 # .slather.yml
-coverage_service: coveralls
+coverage_service: cobertura_xml
 xcodeproj: XpringKit.xcodeproj
 scheme: XpringKit_iOS
 ci_service: circleci

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CircleCI](https://img.shields.io/circleci/build/github/xpring-eng/xpringkit/master?style=flat-square&token=0ed9e0790d44d163a5bf2793724fc85d98c3845b)](https://circleci.com/gh/xpring-eng/xpringkit/tree/master) [![CodeCov](https://img.shields.io/codecov/c/github/xpring-eng/xpringkit/master?style=flat-square&token=08b799e2895a4dd6add40c4621880c1a)]((https://codecov.io/gh/xpring-eng/xpringkit))
+
 # XpringKit
 
 XpringKit is the Swift client side library of the Xpring SDK.


### PR DESCRIPTION
CodeCov's reliability seems higher even though their UI is a bit worse than Coveralls. 

Also, Coveralls is causing this repo's build to fail because renaming the repository so this also fixes this repo's CI. 