### PR TITLE
Run CocoaPods integration as part of CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             brew install xcodegen swiftlint carthage swift-protobuf grpc-swift
             brew upgrade
             npm i -g grpc-tools
-            sudo gem install slather
+            sudo gem install slather cocoapods
 
       - run:
           name: "Pull Submodules"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,12 @@ jobs:
           key: v1-dependencies-{{ checksum "Cartfile.resolved" }}
 
       - run:
-          name: "Build and Test"
+          name: "Build and Test (Carthage)"
           command: set -o pipefail && xcodebuild test -scheme XpringKit_iOS -destination 'platform=iOS Simulator,name=iPhone X,OS=12.2' ONLY_ACTIVE_ARCH=YES | xcpretty
+
+      - run:
+          name: "Build and Test (CocoaPods)"
+          command: pod lib lint
 
       - run:
           name: "Generate and Upload Code Coverage"

--- a/XpringKit.podspec
+++ b/XpringKit.podspec
@@ -3,7 +3,11 @@ Pod::Spec.new do |spec|
   spec.version      = "1.0.3"
   spec.summary      = "XpringKit provides a Swift based SDK for interacting with Xpring Platform (XRP/ILP)"
 
-  spec.description  = "XpringKit provides a Swift based SDK for interacting with Xpring Platform (XRP/ILP)"
+  spec.description  = "
+    XpringKit provides a Swift based SDK for interacting with Xpring Platform (XRP/ILP)
+
+    XpringKit is part of the Xpring SDK. To learn more, visit: http://github.com/xpring-eng/Xpring-SDK.
+  "
 
   spec.homepage     = "http://xpring.io"
   spec.license      = "MIT"


### PR DESCRIPTION
There are two build systems for Swift: 
- CocoaPods
- Carthage

Carthage is currently used to generate the project, while CocoaPods is supported but not tested. This PR adds support for CocoaPods. 