### PR TITLE
Implement X-address encoding and decoding

### DIFF
--- a/Tests/UtilsTest.swift
+++ b/Tests/UtilsTest.swift
@@ -2,35 +2,117 @@ import XCTest
 import XpringKit
 
 class UtilsTest: XCTestCase {
+
+  // MARK: - isValid
+
 	func testIsValidAddressValidClassicAddress() {
-		XCTAssertTrue(Utils.isValid(address: "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"))
+    XCTAssertTrue(Utils.isValid(address: "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"))
 	}
 
-    func testIsValidAddressValidXAddress() {
-        XCTAssertTrue(Utils.isValid(address: "XVLhHMPHU98es4dbozjVtdWzVrDjtV18pX8yuPT7y4xaEHi"))
-    }
+  func testIsValidAddressValidXAddress() {
+    XCTAssertTrue(Utils.isValid(address: "XVLhHMPHU98es4dbozjVtdWzVrDjtV18pX8yuPT7y4xaEHi"))
+  }
 
 	func testIsValidAddressInvalidAlphabet() {
-		XCTAssertFalse(Utils.isValid(address: "1EAG1MwmzkG6gRZcYqcRMfC17eMt8TDTit"))
+    XCTAssertFalse(Utils.isValid(address: "1EAG1MwmzkG6gRZcYqcRMfC17eMt8TDTit"))
 	}
 
 	func testIsvValidAddressInvalidChecksumClassicAddress() {
-		XCTAssertFalse(Utils.isValid(address: "rU6K7V3Po4sBBBBBaU29sesqs2qTQJWDw1"))
+    XCTAssertFalse(Utils.isValid(address: "rU6K7V3Po4sBBBBBaU29sesqs2qTQJWDw1"))
 	}
 
-    func testIsvValidAddressInvalidChecksumXAddress() {
-        XCTAssertFalse(Utils.isValid(address: "XVLhHMPHU98es4dbozjVtdWzVrDjtV18pX8yuPT7y4xaEHI"))
-    }
+  func testIsvValidAddressInvalidChecksumXAddress() {
+    XCTAssertFalse(Utils.isValid(address: "XVLhHMPHU98es4dbozjVtdWzVrDjtV18pX8yuPT7y4xaEHI"))
+  }
 
 	func testIsValidAddressInvalidCharacters() {
-		XCTAssertFalse(Utils.isValid(address: "rU6K7V3Po4sBBBBBaU@#$%qs2qTQJWDw1"))
+    XCTAssertFalse(Utils.isValid(address: "rU6K7V3Po4sBBBBBaU@#$%qs2qTQJWDw1"))
 	}
 
 	func testIsValidAddressTooLong() {
-		XCTAssertFalse(Utils.isValid(address: "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"))
+    XCTAssertFalse(Utils.isValid(address: "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"))
 	}
 
 	func testIsValidAddressTooShort() {
-		XCTAssertFalse(Utils.isValid(address: "rU6K7V3Po4s2qTQJWDw1"))
+    XCTAssertFalse(Utils.isValid(address: "rU6K7V3Po4s2qTQJWDw1"))
 	}
+
+  // MARK: - encode
+
+  func testEncodeXAddressWithAddressAndTag() {
+    // GIVEN a valid classic address and a tag.
+    let address =  "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"
+    let tag: UInt32 = 12_345
+
+    // WHEN they are encoded to an x-address.
+    let xAddress = Utils.encode(classicAddress: address, tag: tag)
+
+    // THEN the result is as expected.
+    XCTAssertEqual(xAddress, "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT")
+  }
+
+  func testEncodeXAddressWithAddressOnly() {
+    // GIVEN a valid classic address.
+    let address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"
+
+    // WHEN it is encoded to an x-address.
+    let xAddress = Utils.encode(classicAddress: address)
+
+    // THEN the result is as expected.
+    XCTAssertEqual(xAddress, "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUFyQVMzRrMGUZpokKH")
+  }
+
+  func testEncodeXAddressWithInvalidAddress() {
+    // GIVEN an invalid address.
+    let address = "xrp"
+
+    // WHEN it is encoded to an x-address.
+    let xAddress = Utils.encode(classicAddress: address)
+
+    // THEN the result is undefined.
+    XCTAssertNil(xAddress)
+  }
+
+  // MARK: - decode
+
+  func testDecodeXAddressWithAddressAndTag() {
+    // GIVEN an x-address that encodes an address and a tag.
+    let address = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT"
+
+    // WHEN it is decoded to an classic address
+    guard let classicAddressTuple = Utils.decode(xAddress: address) else {
+      XCTFail("Failed to decode a valid X-Address")
+      return
+    }
+
+    // THEN the decoded address and tag as are expected.
+    XCTAssertEqual(classicAddressTuple.classicAddress, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1")
+    XCTAssertEqual(classicAddressTuple.tag, 12_345)
+  }
+
+  func testDecodeXAddressWithAddressOnly() {
+    // GIVEN an x-address that encodes an address and no tag.
+    let address = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUFyQVMzRrMGUZpokKH"
+
+    // WHEN it is decoded to an classic address
+    guard let classicAddressTuple = Utils.decode(xAddress: address) else {
+      XCTFail("Failed to decode a valid X-Address")
+      return
+    }
+
+    // THEN the decoded address and tag as are expected.
+    XCTAssertEqual(classicAddressTuple.classicAddress, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1")
+    XCTAssertNil(classicAddressTuple.tag)
+  }
+
+  func testDecodXAddresWithInvalidAddress() {
+    // GIVEN an invalid address
+    let address = "xrp"
+
+    // WHEN it is decoded to an classic address
+    let classicAddressTuple = Utils.decode(xAddress: address)
+
+    // THEN the decoded address is undefined.
+    XCTAssertNil(classicAddressTuple)
+  }
 }

--- a/XpringKit/Address.swift
+++ b/XpringKit/Address.swift
@@ -1,3 +1,5 @@
 import Foundation
 
+// An address in the Ripple ecosystem. Either an X-Address or a classic address.
+/// - SeeAlso: https://xrpaddress.info/
 public typealias Address = String

--- a/XpringKit/JavaScript/JavaScriptUtils.swift
+++ b/XpringKit/JavaScript/JavaScriptUtils.swift
@@ -5,18 +5,28 @@ import JavaScriptCore
 internal class JavaScriptUtils {
 	/// String constants which refer to named JavaScript resources.
 	private enum ResourceNames {
-		public static let isValidAddress = "isValidAddress"
-		public static let utils = "Utils"
+    public static let address = "address"
+    public static let tag = "tag"
+    public static let isValidAddress = "isValidAddress"
+    public static let decodeXAddress = "decodeXAddress"
+    public static let encodeXAddress = "encodeXAddress"
+    public static let utils = "Utils"
 	}
 
 	/// Native javaScript functions wrapped by this class.
 	private let isValidAddressFunction: JSValue
+    private let encodeXAddressFunction: JSValue
+    private let decodeXAddressFunction: JSValue
 
 	/// Initialize a JavaScriptUtils object.
 	public init() {
 		let context = XRPJavaScriptLoader.XRPJavaScriptContext
+
 		let utils = XRPJavaScriptLoader.load(ResourceNames.utils, from: context)
-		isValidAddressFunction = XRPJavaScriptLoader.load(ResourceNames.isValidAddress, from: utils)
+
+        isValidAddressFunction = XRPJavaScriptLoader.load(ResourceNames.isValidAddress, from: utils)
+        encodeXAddressFunction = XRPJavaScriptLoader.load(ResourceNames.encodeXAddress, from: utils)
+        decodeXAddressFunction = XRPJavaScriptLoader.load(ResourceNames.decodeXAddress, from: utils)
 	}
 
 	/// Check if the given address is a valid XRP address.
@@ -29,4 +39,41 @@ internal class JavaScriptUtils {
 		let result = isValidAddressFunction.call(withArguments: [ address ])!
 		return result.toBool()
 	}
+
+    /// Encode the given classic address and tag into an x-address.
+    ///
+    /// - SeeAlso: https://xrpaddress.info/
+    ///
+    /// - Parameters:
+    ///   -  classicAddress: A classic address to encode.
+    ///   - tag: An optional tag to encode. Defaults to nil.
+    /// - Returns: A new x-address if inputs were valid, otherwise undefined.
+    public func encode(classicAddress: Address, tag: UInt32? = nil) -> Address? {
+      var arguments: [Any] = [ classicAddress ]
+      if tag != nil {
+        arguments.append(tag as Any)
+      }
+
+      let result = encodeXAddressFunction.call(withArguments: arguments)!
+      return result.isUndefined ? nil : result.toString()
+    }
+
+    /// Decode a classic address from a given x-address.
+    ///
+    /// - SeeAlso: https://xrpaddress.info/
+    ///
+    /// - Parameter xAddress: The xAddress to decode.
+    /// - Returns: a tuple containing the decoded address and tag.
+    public func decode(xAddress: Address) -> (classicAddress: String, tag: UInt32?)? {
+      let result = decodeXAddressFunction.call(withArguments: [ xAddress ])!
+      guard !result.isUndefined else {
+        return nil
+      }
+
+      let classicAddress = XRPJavaScriptLoader.load(ResourceNames.address, from: result).toString()!
+      if let tag = XRPJavaScriptLoader.failableLoad(ResourceNames.tag, from: result) {
+        return (classicAddress, tag.toUInt32())
+      }
+      return (classicAddress, nil)
+    }
 }

--- a/XpringKit/JavaScript/XRPJavaScriptLoader.swift
+++ b/XpringKit/JavaScript/XRPJavaScriptLoader.swift
@@ -48,7 +48,7 @@ internal enum XRPJavaScriptLoader {
 		return context
 	}
 
-	/// Load a class or function from the default entry point on the given JSContext.
+	/// Load a class, parameter or function from the default entry point on the given JSContext.
 	///
 	/// This method loads value from `EntryPoint.default.<value>`.
 	///
@@ -71,7 +71,7 @@ internal enum XRPJavaScriptLoader {
 		return load(resourceName, from: `default`)
 	}
 
-	/// Load a class or function as a keyed subscript from the given value.
+	/// Load a class, parameter or function as a keyed subscript from the given value.
 	///
 	/// - Note: This function will crash if the requested resource does not exist.
 	///
@@ -80,14 +80,27 @@ internal enum XRPJavaScriptLoader {
 	///		- value: The value to load a resource from.
 	/// - Returns: A `JSValue` referring to the requested resource.
 	public static func load(_ resourceName: String, from value: JSValue) -> JSValue {
-		guard
-			let resource = value.objectForKeyedSubscript(resourceName),
-			!resource.isUndefined
-		else {
+    guard let resource = failableLoad(resourceName, from: value) else {
 			let errorMessage = String(format: LoaderErrors.missingResource, resourceName)
 			fatalError(errorMessage)
 		}
 
 		return resource
 	}
+
+  /// Load a class, parameter or function as a keyed subscript from the given value.
+  ///
+  /// - Parameters:
+  ///    - resourceName: The name of the resource to load.
+  ///    - value: The value to load a resource from.
+  /// - Returns: A `JSValue` referring to the requested resource.
+  public static func failableLoad(_ resourceName: String, from value: JSValue) -> JSValue? {
+    guard
+      let resource = value.objectForKeyedSubscript(resourceName),
+      !resource.isUndefined
+    else {
+      return nil
+    }
+    return resource
+  }
 }

--- a/XpringKit/Utils.swift
+++ b/XpringKit/Utils.swift
@@ -12,4 +12,26 @@ public enum Utils {
 	public static func isValid(address: Address) -> Bool {
 		return javaScriptUtils.isValid(address: address)
 	}
+
+  /// Encode the given classic address and tag into an x-address.
+  ///
+  /// - SeeAlso: https://xrpaddress.info/
+  ///
+  /// - Parameters:
+  ///   -  classicAddress: A classic address to encode.
+  ///   - tag: An optional tag to encode. Defaults to nil.
+  /// - Returns: A new x-address if inputs were valid, otherwise undefined.
+  public static func encode(classicAddress: Address, tag: UInt32? = nil) -> Address? {
+    return javaScriptUtils.encode(classicAddress: classicAddress, tag: tag)
+  }
+
+  /// Decode a classic address from a given x-address.
+  ///
+  /// - SeeAlso: https://xrpaddress.info/
+  ///
+  /// - Parameter xAddress: The xAddress to decode.
+  /// - Returns: a tuple containing the decoded address and tag.
+  public static func decode(xAddress: Address) -> (classicAddress: String, tag: UInt32?)? {
+    return javaScriptUtils.decode(xAddress: xAddress)
+  }
 }


### PR DESCRIPTION
Add APIs to encode and decode x-addresses.

Analog to and passes the same tests as: 
https://github.com/xpring-eng/xpring-common-js/pull/43