### PR TITLE
Add Bindings for Classic and XAddress Checks

### DIFF
--- a/Tests/UtilsTest.swift
+++ b/Tests/UtilsTest.swift
@@ -37,6 +37,76 @@ class UtilsTest: XCTestCase {
     XCTAssertFalse(Utils.isValid(address: "rU6K7V3Po4s2qTQJWDw1"))
 	}
 
+  // MARK: - isValidXAddress
+
+  func testIsValidXAddressWithXAddress() {
+    // GIVEN a valid X-Address.
+    let address = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT"
+
+    // WHEN the address is validated for being an X-Address.
+    let isValid = Utils.isValidXAddress(address: address)
+
+    // THEN the address is reported as valid.
+    XCTAssertTrue(isValid)
+  }
+
+  func testIsValidXAddressWithClassicAddress() {
+    // GIVEN a valid classic address.
+    let address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"
+
+    // WHEN the address is validated for being an X-Address.
+    let isValid = Utils.isValidXAddress(address: address)
+
+    // THEN the address is reported as invalid.
+    XCTAssertFalse(isValid)
+  }
+
+  func testIsValidXAddressWithInvalidAddress() {
+    // GIVEN an invalid address.
+    let address = "xrp"
+
+    // WHEN the address is validated for being an X-Address.
+    let isValid = Utils.isValidXAddress(address: address)
+
+    // THEN the address is reported as invalid.
+    XCTAssertFalse(isValid)
+  }
+
+  // MARK: - isValidClassicAddress
+
+  func testIsValidClassicAddressWithXAddress() {
+    // GIVEN a valid X-Address.
+    let address = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT"
+
+    // WHEN the address is validated for being a classic address.
+    let isValid = Utils.isValidClassicAddress(address: address)
+
+    // THEN the address is reported as valid.
+    XCTAssertFalse(isValid)
+  }
+
+  func testIsValidClassicAddressWithClassicAddress() {
+    // GIVEN a valid classic address.
+    let address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"
+
+    // WHEN the address is validated for being a classic address.
+    let isValid = Utils.isValidClassicAddress(address: address)
+
+    // THEN the address is reported as invalid.
+    XCTAssertTrue(isValid)
+  }
+
+  func testIsValidClassicAddressWithInvalidAddress() {
+    // GIVEN an invalid address.
+    let address = "xrp"
+
+    // WHEN the address is validated for being a classic address.
+    let isValid = Utils.isValidClassicAddress(address: address)
+
+    // THEN the address is reported as invalid.
+    XCTAssertFalse(isValid)
+  }
+
   // MARK: - encode
 
   func testEncodeXAddressWithAddressAndTag() {

--- a/XpringKit/JavaScript/JavaScriptUtils.swift
+++ b/XpringKit/JavaScript/JavaScriptUtils.swift
@@ -6,27 +6,32 @@ internal class JavaScriptUtils {
 	/// String constants which refer to named JavaScript resources.
 	private enum ResourceNames {
     public static let address = "address"
-    public static let tag = "tag"
-    public static let isValidAddress = "isValidAddress"
     public static let decodeXAddress = "decodeXAddress"
     public static let encodeXAddress = "encodeXAddress"
+    public static let isValidAddress = "isValidAddress"
+    public static let isValidClassicAddress = "isValidClassicAddress"
+    public static let isValidXAddress = "isValidXAddress"
+    public static let tag = "tag"
     public static let utils = "Utils"
 	}
 
 	/// Native javaScript functions wrapped by this class.
-	private let isValidAddressFunction: JSValue
-    private let encodeXAddressFunction: JSValue
-    private let decodeXAddressFunction: JSValue
+  private let encodeXAddressFunction: JSValue
+  private let decodeXAddressFunction: JSValue
+  private let isValidAddressFunction: JSValue
+  private let isValidClassicAddressFunction: JSValue
+  private let isValidXAddressFunction: JSValue
 
 	/// Initialize a JavaScriptUtils object.
 	public init() {
 		let context = XRPJavaScriptLoader.XRPJavaScriptContext
 
 		let utils = XRPJavaScriptLoader.load(ResourceNames.utils, from: context)
-
-        isValidAddressFunction = XRPJavaScriptLoader.load(ResourceNames.isValidAddress, from: utils)
-        encodeXAddressFunction = XRPJavaScriptLoader.load(ResourceNames.encodeXAddress, from: utils)
-        decodeXAddressFunction = XRPJavaScriptLoader.load(ResourceNames.decodeXAddress, from: utils)
+    encodeXAddressFunction = XRPJavaScriptLoader.load(ResourceNames.encodeXAddress, from: utils)
+    decodeXAddressFunction = XRPJavaScriptLoader.load(ResourceNames.decodeXAddress, from: utils)
+    isValidAddressFunction = XRPJavaScriptLoader.load(ResourceNames.isValidAddress, from: utils)
+    isValidClassicAddressFunction = XRPJavaScriptLoader.load(ResourceNames.isValidClassicAddress, from: utils)
+    isValidXAddressFunction = XRPJavaScriptLoader.load(ResourceNames.isValidXAddress, from: utils)
 	}
 
 	/// Check if the given address is a valid XRP address.
@@ -40,40 +45,62 @@ internal class JavaScriptUtils {
 		return result.toBool()
 	}
 
-    /// Encode the given classic address and tag into an x-address.
-    ///
-    /// - SeeAlso: https://xrpaddress.info/
-    ///
-    /// - Parameters:
-    ///   -  classicAddress: A classic address to encode.
-    ///   - tag: An optional tag to encode. Defaults to nil.
-    /// - Returns: A new x-address if inputs were valid, otherwise undefined.
-    public func encode(classicAddress: Address, tag: UInt32? = nil) -> Address? {
-      var arguments: [Any] = [ classicAddress ]
-      if tag != nil {
-        arguments.append(tag as Any)
-      }
+  /// Validate if the given string is a valid X-address on the XRP Ledger.
+  ///
+  /// - SeeAlso: https://xrpaddress.info/
+  ///
+  /// - Parameter address: An address to check.
+  /// - Returns true if the address is a valid X-address, otherwise false.
+  public func isValidXAddress(address: Address) -> Bool {
+    let result = isValidXAddressFunction.call(withArguments: [ address ])!
+    return result.toBool()
+  }
 
-      let result = encodeXAddressFunction.call(withArguments: arguments)!
-      return result.isUndefined ? nil : result.toString()
+  /// Validate if the given string is a valid  classic address on the XRP Ledger.
+  ///
+  /// - SeeAlso: https://xrpaddress.info/
+  ///
+  /// - Parameter address: An address to check.
+  /// - Returns true if the address is a valid classic address, otherwise false.
+  public func isValidClassicAddress(address: Address) -> Bool {
+    let result = isValidClassicAddressFunction.call(withArguments: [ address ])!
+    return result.toBool()
+  }
+
+  /// Encode the given classic address and tag into an x-address.
+  ///
+  /// - SeeAlso: https://xrpaddress.info/
+  ///
+  /// - Parameters:
+  ///   -  classicAddress: A classic address to encode.
+  ///   - tag: An optional tag to encode. Defaults to nil.
+  /// - Returns: A new x-address if inputs were valid, otherwise undefined.
+  public func encode(classicAddress: Address, tag: UInt32? = nil) -> Address? {
+    var arguments: [Any] = [ classicAddress ]
+    if tag != nil {
+      arguments.append(tag as Any)
     }
 
-    /// Decode a classic address from a given x-address.
-    ///
-    /// - SeeAlso: https://xrpaddress.info/
-    ///
-    /// - Parameter xAddress: The xAddress to decode.
-    /// - Returns: a tuple containing the decoded address and tag.
-    public func decode(xAddress: Address) -> (classicAddress: String, tag: UInt32?)? {
-      let result = decodeXAddressFunction.call(withArguments: [ xAddress ])!
-      guard !result.isUndefined else {
-        return nil
-      }
+    let result = encodeXAddressFunction.call(withArguments: arguments)!
+    return result.isUndefined ? nil : result.toString()
+  }
 
-      let classicAddress = XRPJavaScriptLoader.load(ResourceNames.address, from: result).toString()!
-      if let tag = XRPJavaScriptLoader.failableLoad(ResourceNames.tag, from: result) {
-        return (classicAddress, tag.toUInt32())
-      }
-      return (classicAddress, nil)
+  /// Decode a classic address from a given x-address.
+  ///
+  /// - SeeAlso: https://xrpaddress.info/
+  ///
+  /// - Parameter xAddress: The xAddress to decode.
+  /// - Returns: a tuple containing the decoded address and tag.
+  public func decode(xAddress: Address) -> (classicAddress: String, tag: UInt32?)? {
+    let result = decodeXAddressFunction.call(withArguments: [ xAddress ])!
+    guard !result.isUndefined else {
+      return nil
     }
+
+    let classicAddress = XRPJavaScriptLoader.load(ResourceNames.address, from: result).toString()!
+    if let tag = XRPJavaScriptLoader.failableLoad(ResourceNames.tag, from: result) {
+      return (classicAddress, tag.toUInt32())
+    }
+    return (classicAddress, nil)
+  }
 }

--- a/XpringKit/Utils.swift
+++ b/XpringKit/Utils.swift
@@ -13,6 +13,26 @@ public enum Utils {
 		return javaScriptUtils.isValid(address: address)
 	}
 
+  /// Validate if the given string is a valid X-address on the XRP Ledger.
+  ///
+  /// - SeeAlso: https://xrpaddress.info/
+  ///
+  /// - Parameter address: An address to check.
+  /// - Returns true if the address is a valid X-address, otherwise false.
+  public static func isValidXAddress(address: Address) -> Bool {
+    return javaScriptUtils.isValidXAddress(address: address)
+  }
+
+  /// Validate if the given string is a valid  classic address on the XRP Ledger.
+  ///
+  /// - SeeAlso: https://xrpaddress.info/
+  ///
+  /// - Parameter address: An address to check.
+  /// - Returns true if the address is a valid classic address, otherwise false.
+  public static func isValidClassicAddress(address: Address) -> Bool {
+    return javaScriptUtils.isValidClassicAddress(address: address)
+  }
+
   /// Encode the given classic address and tag into an x-address.
   ///
   /// - SeeAlso: https://xrpaddress.info/

--- a/scripts/clean_project.sh
+++ b/scripts/clean_project.sh
@@ -6,6 +6,6 @@ echo "Cleaning XpringKit Project"
 
 rm -rf *.xcodeproj
 rm -rf XpringKit/generated
-rm XpringKit/Resources/bundled.js
+rm -f XpringKit/Resources/bundled.js
 
 echo "All Done"


### PR DESCRIPTION
Add bindings for `isXAddress()` and `isClassicAddress()` in Swift. Unit test implementations. 

Tests taken from the [implementation in JavaScript](https://github.com/xpring-eng/xpring-common-js/pull/50)