### PR TITLE
Implement Destination Tag Functionality 

### DIFF
--- a/Tests/XpringClientTest.swift
+++ b/Tests/XpringClientTest.swift
@@ -28,16 +28,18 @@ final class XpringClientTest: XCTestCase {
 		$0.engineResultCode = engineResultCode
 	}
 
+  /// A network client that always succeeds.
+  static let successfulFakeNetworkClient = FakeNetworkClient(
+    accountInfoResult: .success(XpringClientTest.accountInfo),
+    feeResult: .success(XpringClientTest.fee),
+    submitSignedTransactionResult: .success(XpringClientTest.submitTransactionResponse)
+  )
+
 	// MARK: - Balance
 
 	func testGetBalanceWithSuccess() {
 		// GIVEN a Xpring client which will successfully return a balance from a mocked network call.
-		let networkClient = FakeNetworkClient(
-			accountInfoResult: .success(XpringClientTest.accountInfo),
-			feeResult: .success(XpringClientTest.fee),
-			submitSignedTransactionResult: .success(XpringClientTest.submitTransactionResponse)
-		)
-		let xpringClient = XpringClient(networkClient: networkClient)
+    let xpringClient = XpringClient(networkClient: XpringClientTest.successfulFakeNetworkClient)
 
 		// WHEN the balance is requested.
 		guard let balance = try? xpringClient.getBalance(for: .testAddress) else {
@@ -66,12 +68,7 @@ final class XpringClientTest: XCTestCase {
 
 	func testSendWithSuccess() {
 		// GIVEN a Xpring client which will successfully return a balance from a mocked network call.
-		let networkClient = FakeNetworkClient(
-			accountInfoResult: .success(XpringClientTest.accountInfo),
-			feeResult: .success(XpringClientTest.fee),
-			submitSignedTransactionResult: .success(XpringClientTest.submitTransactionResponse)
-		)
-		let xpringClient = XpringClient(networkClient: networkClient)
+    let xpringClient = XpringClient(networkClient: XpringClientTest.successfulFakeNetworkClient)
 
 		// WHEN XRP is sent.
 		guard

--- a/Tests/XpringClientTest.swift
+++ b/Tests/XpringClientTest.swift
@@ -1,68 +1,168 @@
 import XCTest
 @testable import XpringKit
 
-extension Wallet {
-  public static let testWallet = Wallet(seed: "saNTy6oyVyMhCScBdKUNg2tFWwPKa")!
-}
-
 final class XpringClientTest: XCTestCase {
-  let xrpClient = XpringClient(grpcURL: .grpcURL)
-
-  func testClassicAddressSend() {
-    // An address to receive XRP.
-    let recipientAddress = "rsegqrgSP8XmhCYwL9enkZ9BNDNawfPZnn"
-
-    let result = try! xrpClient.send(.oneDrop, to: recipientAddress, from: .testWallet)
-
-    print("Sent to a classic address with result: \(result.engineResultMessage)")
+  static let wallet = Wallet(seed: "snYP7oArxKepd3GPDcrjMsJYiJeJB")!
+  static let destinationAddress = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"
+  static let sendDrops = "20"
+  static let sendAmount = Io_Xpring_XRPAmount.with {
+    $0.drops = sendDrops
   }
 
-  func testClassicAddressWithTag() {
-    // An address and tag to receive XRP.
-    let recipientAddress = "rsegqrgSP8XmhCYwL9enkZ9BNDNawfPZnn"
-    let recipientTag: UInt32 = 123
-
-    let result = try! xrpClient.send(.twoDrops, to: recipientAddress, destinationTag: recipientTag, from: .testWallet)
-    print("Sent to a classic address and a tag with result: \(result.engineResultMessage)")
+  static let feeDrops = "15"
+  static let balance = "1000"
+  static let sequence: UInt64 = 2
+  static let accountInfo = Io_Xpring_AccountInfo.with {
+    $0.balance = Io_Xpring_XRPAmount.with {
+      $0.drops = balance
+    }
+    $0.sequence = sequence
   }
 
-  func testXAddress() {
-    // An X-Address that's going to get some XRP
-    let recipientAddress = "X7cBcY4bdTTzk3LHmrKAK6GyrirkXfTSaLz88QUHWjDGoao"
-    let result = try! xrpClient.send(.threeDrops, to: recipientAddress, from: .testWallet)
-    print("Sent to a classic address with result: \(result.engineResultMessage)")
+  static let fee = Io_Xpring_Fee.with {
+    $0.amount = Io_Xpring_XRPAmount.with {
+      $0.drops = feeDrops
+    }
   }
 
-  func testSendWithEncodeXAddress() {
-    // Some classic address inputs
-    let recipientAddress = "rsegqrgSP8XmhCYwL9enkZ9BNDNawfPZnn"
-    let recipientTag: UInt32 = 123
-
-    // Make an X-Address!
-    let xAddress = Utils.encode(classicAddress: recipientAddress, tag: recipientTag)!
-    print("Derived the corresponding X-Address as: \(xAddress)")
-
-    // Send to that address
-    let result = try! xrpClient.send(.fourDrops, to: xAddress, from: .testWallet)
-    print("Sent to a derived X-Address result: \(result.engineResultMessage)")
+  static let engineResultCode: Int64 = 0
+  static let submitTransactionResponse = Io_Xpring_SubmitSignedTransactionResponse.with {
+    $0.engineResultCode = engineResultCode
   }
 
-  override func setUp() {
-    print("\n\n")
+  /// A fake network client which always succeeds.
+  static let successfulFakeNetworkClient = FakeNetworkClient(
+    accountInfoResult: .success(XpringClientTest.accountInfo),
+    feeResult: .success(XpringClientTest.fee),
+    submitSignedTransactionResult: .success(XpringClientTest.submitTransactionResponse)
+  )
+
+  // MARK: - Balance
+
+  func testGetBalanceWithSuccess() {
+    // GIVEN a Xpring client which will successfully return a balance from a mocked network call.
+    let xpringClient = XpringClient(networkClient: XpringClientTest.successfulFakeNetworkClient)
+
+    // WHEN the balance is requested.
+    guard let xrpAmount = try? xpringClient.getBalance(for: .testAddress) else {
+      XCTFail("Exception should not be thrown when trying to get a balance")
+      return
+    }
+
+    // THEN the balance is correct.
+    XCTAssertEqual(xrpAmount.drops, XpringClientTest.balance)
   }
 
-  override func tearDown() {
-    print("\n\n")
+  func testGetBalanceWithFailure() {
+    // GIVEN a Xpring client which will throw an error when a balance is requested.
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .failure(XpringKitTestError.mockFailure),
+      feeResult: .success(XpringClientTest.fee),
+      submitSignedTransactionResult: .success(XpringClientTest.submitTransactionResponse)
+    )
+    let xpringClient = XpringClient(networkClient: networkClient)
+
+    // WHEN the balance is requested THEN the error is thrown.
+    XCTAssertThrowsError(try xpringClient.getBalance(for: .testAddress))
   }
-}
 
-extension Io_Xpring_XRPAmount {
-  public static let oneDrop = Io_Xpring_XRPAmount.with { $0.drops = "1" }
-  public static let twoDrops = Io_Xpring_XRPAmount.with { $0.drops = "2" }
-  public static let threeDrops = Io_Xpring_XRPAmount.with { $0.drops = "3" }
-  public static let fourDrops = Io_Xpring_XRPAmount.with { $0.drops = "4" }
-}
+  // MARK: - Send
 
-extension String {
-  public static let grpcURL = "grpc.xpring.tech:80"
+  func testSendWithSuccess() {
+    // GIVEN a Xpring client which will successfully return a balance from a mocked network call.
+    let xpringClient = XpringClient(networkClient: XpringClientTest.successfulFakeNetworkClient)
+
+    // WHEN XRP is sent.
+    guard
+      let result = try? xpringClient.send(
+        XpringClientTest.sendAmount,
+        to: XpringClientTest.destinationAddress,
+        from: XpringClientTest.wallet)
+    else {
+      XCTFail("Exception should not be thrown when trying to send XRP")
+      return
+    }
+
+    // THEN the engine result code is as expected.
+    XCTAssertEqual(result.engineResultCode, XpringClientTest.engineResultCode)
+  }
+
+  func testSendWithInvalidAddress() {
+    // GIVEN a Xpring client and an invalid destination address.
+    let xpringClient = XpringClient(networkClient: XpringClientTest.successfulFakeNetworkClient)
+    let destinationAddress = "xrp"
+
+    // WHEN XRP is sent to an invalid address THEN an error is thrown.
+    XCTAssertThrowsError(try xpringClient.send(
+      XpringClientTest.sendAmount,
+      to: destinationAddress,
+      from: XpringClientTest.wallet
+    ))
+  }
+
+  func testSendWithXAddressAndTag() {
+    // GIVEN a Xpring client, an X-Address and a destination tag.
+    let xpringClient = XpringClient(networkClient: XpringClientTest.successfulFakeNetworkClient)
+    let xAddress = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUFyQVMzRrMGUZpokKH"
+    let destinationTag: UInt32 = 123
+
+    // WHEN XRP is sent THEN an error is thrown.
+    XCTAssertThrowsError(try xpringClient.send(
+      XpringClientTest.sendAmount,
+      to: xAddress,
+      destinationTag: destinationTag,
+      from: XpringClientTest.wallet
+    ))
+  }
+
+  func testSendWithAccountInfoFailure() {
+    // GIVEN a Xpring client which will fail to return account info.
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .failure(XpringKitTestError.mockFailure),
+      feeResult: .success(XpringClientTest.fee),
+      submitSignedTransactionResult: .success(XpringClientTest.submitTransactionResponse)
+    )
+    let xpringClient = XpringClient(networkClient: networkClient)
+
+    // WHEN a send is attempted THEN an error is thrown.
+    XCTAssertThrowsError(try xpringClient.send(
+      XpringClientTest.sendAmount,
+      to: XpringClientTest.destinationAddress,
+      from: XpringClientTest.wallet
+    ))
+  }
+
+  func testSendWithFeeFailure() {
+    // GIVEN a Xpring client which will fail to return a fee.
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .success(XpringClientTest.accountInfo),
+      feeResult: .failure(XpringKitTestError.mockFailure),
+      submitSignedTransactionResult: .success(XpringClientTest.submitTransactionResponse)
+    )
+    let xpringClient = XpringClient(networkClient: networkClient)
+
+    // WHEN a send is attempted then an error is thrown.
+    XCTAssertThrowsError(try xpringClient.send(
+      XpringClientTest.sendAmount,
+      to: XpringClientTest.destinationAddress,
+      from: XpringClientTest.wallet
+    ))
+  }
+
+  func testSendWithSubmitFailure() {
+    // GIVEN a Xpring client which will fail to submit a transaction.
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .success(XpringClientTest.accountInfo),
+      feeResult: .success(XpringClientTest.fee),
+      submitSignedTransactionResult: .failure(XpringKitTestError.mockFailure)
+    )
+    let xpringClient = XpringClient(networkClient: networkClient)
+
+    // WHEN a send is attempted then an error is thrown.
+    XCTAssertThrowsError(try xpringClient.send(
+      XpringClientTest.sendAmount,
+      to: XpringClientTest.destinationAddress,
+      from: XpringClientTest.wallet
+    ))
+  }
 }

--- a/XpringKit/XRPLedgerError.swift
+++ b/XpringKit/XRPLedgerError.swift
@@ -2,4 +2,8 @@
 public enum XRPLedgerError: Error {
 	/// A problem occurred while performing the cryptographic signing process.
 	case signingError
+
+  case invalidAddress(String)
+  case invalidInputs(String)
+  case unknown(String)
 }

--- a/XpringKit/XRPLedgerError.swift
+++ b/XpringKit/XRPLedgerError.swift
@@ -1,9 +1,14 @@
 /// Errors that may occur when interacting with the XRP Ledger.
 public enum XRPLedgerError: Error {
-	/// A problem occurred while performing the cryptographic signing process.
-	case signingError
+  /// A problem occurred while performing the cryptographic signing process.
+  case signingError
 
+  /// An invalid address was given. The invalid addresss is provided as an associated value.
   case invalidAddress(String)
+
+  /// An invalid address was given. A more descriptive string is provided as an associated value.
   case invalidInputs(String)
+
+  /// An invalid address was given. A more descriptive string is provided as an associated value.
   case unknown(String)
 }

--- a/XpringKit/XpringClient.swift
+++ b/XpringKit/XpringClient.swift
@@ -45,10 +45,10 @@ public class XpringClient {
   /// Send XRP to a recipient on the XRP Ledger.
   ///
   /// - Parameters:
-	///		- amount: An unsigned integer representing the amount of XRP to send.
-  ///    - destinationAddress: The address which will receive the XRP.
-  ///    - destinationTag: A tag for the destination address.
-  ///    - sourceWallet: The wallet sending the XRP.
+  ///   - amount: An unsigned integer representing the amount of XRP to send.
+  ///   - destinationAddress: The address which will receive the XRP.
+  ///   - destinationTag: A tag for the destination address.
+  ///   - sourceWallet: The wallet sending the XRP.
   /// - Throws: An error if there was a problem communicating with the XRP Ledger.
   /// - Returns: A response from the ledger.
   public func send(


### PR DESCRIPTION
Implement the ability to send to a destination tag. 

This is implemented by converting any given inputs to an X-Address which is then input into the `Transaction` protocol buffer.  Internally, XpringKit now deals with only X-Addresses. 

Clients can use this API as follows:
```swift
/// Send to a classic address, same as before
xpringClient.send(amount, to: "r....", from: myWallet)

/// Send to a classic address and tag, simply add a new param to above method
xpringClient.send(amount, to: "r....", destinationTag: 123, from: myWallet)

/// Send to an X-address (with or without tag encoded), same as first:
xpringClient.send(amoutn, to: "X....", from: myWallet)

/// Send using an X-Address, if you have classic address and tag:
let xAddress = Utils.encodeXAddress(classicAddress: "r...", tag: 123)
// Same as 1 and 3
xpringClient.send(amount, to: xAddress, from: myWallet)
```

Note: I will likely update the documentation in one fell swoop and get a proper review from a tech writer. These APIs aren't accessible until I cut a new release and I'd like the README to reflect what artifacts are currently published. 