### PR TITLE
Migrate Public API to using BigInt

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,3 @@
 github "apple/swift-protobuf" == 1.6.0
+github "attaswift/BigInt" == 5.0.0
 github "grpc/grpc-swift" == 0.9.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,3 @@
 github "apple/swift-protobuf" "1.6.0"
+github "attaswift/BigInt" "v5.0.0"
 github "grpc/grpc-swift" "0.9.1"

--- a/Tests/XpringClientTest.swift
+++ b/Tests/XpringClientTest.swift
@@ -1,20 +1,18 @@
+import BigInt
 import XCTest
 @testable import XpringKit
 
 final class XpringClientTest: XCTestCase {
 	static let wallet = Wallet(seed: "snYP7oArxKepd3GPDcrjMsJYiJeJB")!
 	static let destinationAddress = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"
-	static let sendDrops = "20"
-	static let sendAmount = Io_Xpring_XRPAmount.with {
-		$0.drops = sendDrops
-	}
+	static let sendAmount = BigUInt(stringLiteral: "20")
 
 	static let feeDrops = "15"
-	static let balance = "1000"
+	static let balance = BigUInt(stringLiteral: "1000")
 	static let sequence: UInt64 = 2
 	static let accountInfo = Io_Xpring_AccountInfo.with {
 		$0.balance = Io_Xpring_XRPAmount.with {
-			$0.drops = balance
+			$0.drops = String(balance)
 		}
 		$0.sequence = sequence
 	}
@@ -42,13 +40,13 @@ final class XpringClientTest: XCTestCase {
 		let xpringClient = XpringClient(networkClient: networkClient)
 
 		// WHEN the balance is requested.
-		guard let xrpAmount = try? xpringClient.getBalance(for: .testAddress) else {
+		guard let balance = try? xpringClient.getBalance(for: .testAddress) else {
 			XCTFail("Exception should not be thrown when trying to get a balance")
 			return
 		}
 
 		// THEN the balance is correct.
-		XCTAssertEqual(xrpAmount.drops, XpringClientTest.balance)
+		XCTAssertEqual(balance, XpringClientTest.balance)
 	}
 
 	func testGetBalanceWithFailure() {

--- a/XpringKit.podspec
+++ b/XpringKit.podspec
@@ -24,6 +24,7 @@ Pod::Spec.new do |spec|
   spec.source_files  = "XpringKit/**/*.swift"
   spec.resources =     [ "XpringKit/Resources/*" ]
 
+  spec.dependency 'BigInt'
   spec.dependency 'SwiftGRPC'
   spec.dependency 'SwiftProtobuf'
 

--- a/XpringKit/XpringClient.swift
+++ b/XpringKit/XpringClient.swift
@@ -1,5 +1,6 @@
+import BigInt
+
 /// An interface into the Xpring Platform.
-/// TODO(keefertaylor): Rename this to XRPClient.
 public class XpringClient {
 	/// A network client that will make and receive requests.
 	private let networkClient: NetworkClient
@@ -23,23 +24,27 @@ public class XpringClient {
 	///
 	/// - Parameter address: The address to retrieve the balance for.
 	/// - Throws: An error if there was a problem communicating with the XRP Ledger.
-	/// - Returns: An XRPAmount containing the balance of the address.
-	public func getBalance(for address: Address) throws -> Io_Xpring_XRPAmount {
+	/// - Returns: An unsigned integer containing the balance of the address in drops.
+	public func getBalance(for address: Address) throws -> BigUInt {
 		let accountInfo = try getAccountInfo(for: address)
-		return accountInfo.balance
+    return BigUInt(stringLiteral: accountInfo.balance.drops)
 	}
 
 	/// Send XRP to a recipient on the XRP Ledger.
 	///
 	/// - Parameters:
-	///		- amount: The amount of XRP to send.
+	///		- amount: An unsigned integer representing the amount of XRP to send.
 	///		- destinationAddress: The address which will receive the XRP.
 	///		- sourceWallet: The wallet sending the XRP.
 	/// - Throws: An error if there was a problem communicating with the XRP Ledger.
 	/// - Returns: A response from the ledger.
-	public func send(_ amount: Io_Xpring_XRPAmount, to destinationAddress: Address, from sourceWallet: Wallet) throws -> Io_Xpring_SubmitSignedTransactionResponse {
+	public func send(_ amount: BigUInt, to destinationAddress: Address, from sourceWallet: Wallet) throws -> Io_Xpring_SubmitSignedTransactionResponse {
 		let accountInfo = try getAccountInfo(for: sourceWallet.address)
 		let fee = try getFee()
+
+    let xrpAmount = Io_Xpring_XRPAmount.with {
+      $0.drops = String(amount)
+    }
 
 		let transaction = Io_Xpring_Transaction.with {
 			$0.account = sourceWallet.address
@@ -47,7 +52,7 @@ public class XpringClient {
 			$0.sequence = accountInfo.sequence
 			$0.payment = Io_Xpring_Payment.with {
 				$0.destination = destinationAddress
-				$0.xrpAmount = amount
+				$0.xrpAmount = xrpAmount
 			}
 			$0.signingPublicKeyHex = sourceWallet.publicKey
 		}

--- a/project.yml
+++ b/project.yml
@@ -18,6 +18,7 @@ targets:
       - script: swiftlint autocorrect --config .swiftlint.yml
         name: SwiftLint
     dependencies:
+      - carthage: BigInt
       - carthage: SwiftProtobuf
       - carthage: SwiftGRPC
   XpringKitTests:


### PR DESCRIPTION
Allowing clients to specify amounts of XRP in integer form is more idiomatic and easier to grok for new devs than having a public API which takes:
- protocol buffers
- numeric strings

Apple does not offer a Big Integer library. [BigInt](https://github.com/attaswift/bigint) is a widely used, stable, and well documented third party library which provides this functionality.  

Modify send / balance APIs to speak in `BigUInts` rather than `XRPAmount` protocol buffers. This change is a breaking API change, and the library will get versioned accordingly. 

Note: I will likely update the documentation in one fell swoop and get a proper review from a tech writer. These APIs aren't accessible until I cut a new release and I'd like the README to reflect what artifacts are currently published.