### PR TITLE
Bind Transaction Hashing Function to Swift

### DIFF
--- a/Tests/UtilsTest.swift
+++ b/Tests/UtilsTest.swift
@@ -185,4 +185,31 @@ class UtilsTest: XCTestCase {
     // THEN the decoded address is undefined.
     XCTAssertNil(classicAddressTuple)
   }
+
+  // MARK: - toTransactionHash
+
+  func testToTransactionHashValidTransaction() {
+    // GIVEN a transaction blob.
+    let transactionBlobHex = "120000240000000561400000000000000168400000000000000C73210261BBB9D242440BA38375DAD79B146E559A9DFB99055F7077DA63AE0D643CA0E174473045022100C8BB1CE19DFB1E57CDD60947C5D7F1ACD10851B0F066C28DBAA3592475BC3808022056EEB85CC8CD41F1F1CF635C244943AD43E3CF0CE1E3B7359354AC8A62CF3F488114F8942487EDB0E4FD86190BF8DCB3AF36F608839D83141D10E382F805CD7033CC4582D2458922F0D0ACA6"
+
+    // WHEN the transaction blob is converted to a hash.
+    let transactionHash = Utils.toTransactionHash(transactionBlobHex: transactionBlobHex)
+
+    // THEN the transaction blob is as expected.
+    XCTAssertEqual(
+      transactionHash,
+      "7B9F6E019C2A79857427B4EF968D77D683AC84F5A880830955D7BDF47F120667"
+    )
+  }
+
+  func testToTransactionHashInvalidTransaction() {
+    // GIVEN an invalid transaction blob.
+    let transactionBlobHex = "xrp"
+
+    // WHEN the transaction blob is converted to a hash.
+    let transactionHash = Utils.toTransactionHash(transactionBlobHex: transactionBlobHex)
+
+    // THEN the hash is nil.
+    XCTAssertNil(transactionHash)
+  }
 }

--- a/XpringKit/JavaScript/JavaScriptUtils.swift
+++ b/XpringKit/JavaScript/JavaScriptUtils.swift
@@ -16,25 +16,27 @@ internal class JavaScriptUtils {
     public static let utils = "Utils"
   }
 
-  /// Native javaScript functions wrapped by this class.
+  /// The JavaScript class.
+  private let utils: JSValue
+
+  /// Native JavaScript functions wrapped by this class.
+  // TODO(keefertaylor): This class should use the same pattern as JSWallet, where `invokeMethod` is called on a class object and direct function references are not kept. 
   private let encodeXAddressFunction: JSValue
   private let decodeXAddressFunction: JSValue
   private let isValidAddressFunction: JSValue
   private let isValidClassicAddressFunction: JSValue
   private let isValidXAddressFunction: JSValue
-  private let transactionBlobToTransactionHashFunction: JSValue
 
   /// Initialize a JavaScriptUtils object.
   public init() {
     let context = XRPJavaScriptLoader.XRPJavaScriptContext
 
-    let utils = XRPJavaScriptLoader.load(ResourceNames.utils, from: context)
+    utils = XRPJavaScriptLoader.load(ResourceNames.utils, from: context)
     encodeXAddressFunction = XRPJavaScriptLoader.load(ResourceNames.encodeXAddress, from: utils)
     decodeXAddressFunction = XRPJavaScriptLoader.load(ResourceNames.decodeXAddress, from: utils)
     isValidAddressFunction = XRPJavaScriptLoader.load(ResourceNames.isValidAddress, from: utils)
     isValidClassicAddressFunction = XRPJavaScriptLoader.load(ResourceNames.isValidClassicAddress, from: utils)
     isValidXAddressFunction = XRPJavaScriptLoader.load(ResourceNames.isValidXAddress, from: utils)
-    transactionBlobToTransactionHashFunction = XRPJavaScriptLoader.load(ResourceNames.transactionBlobToTransactionHash, from: utils)
   }
 
   /// Check if the given address is a valid XRP address.
@@ -112,7 +114,7 @@ internal class JavaScriptUtils {
   /// - Parameter transactionBlobHex: A hexadecimal encoded transaction blob.
   /// - Returns: A hex encoded hash if the input was valid, otherwise undefined.
   public func toTransactionHash(transactionBlobHex: Hex) -> Hex? {
-    let result = transactionBlobToTransactionHashFunction.call(withArguments: [transactionBlobHex])!
+    let result = utils.invokeMethod(ResourceNames.transactionBlobToTransactionHash, withArguments: [transactionBlobHex])!
     guard !result.isUndefined else {
         return nil
     }

--- a/XpringKit/JavaScript/JavaScriptUtils.swift
+++ b/XpringKit/JavaScript/JavaScriptUtils.swift
@@ -12,6 +12,7 @@ internal class JavaScriptUtils {
     public static let isValidClassicAddress = "isValidClassicAddress"
     public static let isValidXAddress = "isValidXAddress"
     public static let tag = "tag"
+    public static let transactionBlobToTransactionHash = "transactionBlobToTransactionHash"
     public static let utils = "Utils"
   }
 
@@ -21,6 +22,7 @@ internal class JavaScriptUtils {
   private let isValidAddressFunction: JSValue
   private let isValidClassicAddressFunction: JSValue
   private let isValidXAddressFunction: JSValue
+  private let transactionBlobToTransactionHashFunction: JSValue
 
   /// Initialize a JavaScriptUtils object.
   public init() {
@@ -32,6 +34,7 @@ internal class JavaScriptUtils {
     isValidAddressFunction = XRPJavaScriptLoader.load(ResourceNames.isValidAddress, from: utils)
     isValidClassicAddressFunction = XRPJavaScriptLoader.load(ResourceNames.isValidClassicAddress, from: utils)
     isValidXAddressFunction = XRPJavaScriptLoader.load(ResourceNames.isValidXAddress, from: utils)
+    transactionBlobToTransactionHashFunction = XRPJavaScriptLoader.load(ResourceNames.transactionBlobToTransactionHash, from: utils)
   }
 
   /// Check if the given address is a valid XRP address.
@@ -102,5 +105,17 @@ internal class JavaScriptUtils {
       return (classicAddress, tag.toUInt32())
     }
     return (classicAddress, nil)
+  }
+
+  /// Convert the given transaction blob to a transaction hash.
+  ///
+  /// - Parameter transactionBlobHex: A hexadecimal encoded transaction blob.
+  /// - Returns: A hex encoded hash if the input was valid, otherwise undefined.
+  public func toTransactionHash(transactionBlobHex: Hex) -> Hex? {
+    let result = transactionBlobToTransactionHashFunction.call(withArguments: [transactionBlobHex])!
+    guard !result.isUndefined else {
+        return nil
+    }
+    return result.toString()
   }
 }

--- a/XpringKit/Utils.swift
+++ b/XpringKit/Utils.swift
@@ -54,4 +54,12 @@ public enum Utils {
   public static func decode(xAddress: Address) -> (classicAddress: String, tag: UInt32?)? {
     return javaScriptUtils.decode(xAddress: xAddress)
   }
+
+  /// Convert the given transaction blob to a transaction hash.
+  ///
+  /// - Parameter transactionBlobHex: A hexadecimal encoded transaction blob.
+  /// - Returns: A hex encoded hash if the input was valid, otherwise undefined.
+  public static func toTransactionHash(transactionBlobHex: Hex) -> Hex? {
+    return javaScriptUtils.toTransactionHash(transactionBlobHex: transactionBlobHex)
+  }
 }


### PR DESCRIPTION
Bind up the new Transaction Hashing function to Swift Code. Function implemented in https://github.com/xpring-eng/xpring-common-js/pull/51/files

Tests taken from JavaScript implementation.