### PR TITLE
Return a Transaction Hash rather than complete Rippled response

### DIFF
--- a/Tests/UtilsTest.swift
+++ b/Tests/UtilsTest.swift
@@ -185,4 +185,31 @@ class UtilsTest: XCTestCase {
     // THEN the decoded address is undefined.
     XCTAssertNil(classicAddressTuple)
   }
+
+  // MARK: - toTransactionHash
+
+  func testToTransactionHashValidTransaction() {
+    // GIVEN a transaction blob.
+    let transactionBlobHex = "120000240000000561400000000000000168400000000000000C73210261BBB9D242440BA38375DAD79B146E559A9DFB99055F7077DA63AE0D643CA0E174473045022100C8BB1CE19DFB1E57CDD60947C5D7F1ACD10851B0F066C28DBAA3592475BC3808022056EEB85CC8CD41F1F1CF635C244943AD43E3CF0CE1E3B7359354AC8A62CF3F488114F8942487EDB0E4FD86190BF8DCB3AF36F608839D83141D10E382F805CD7033CC4582D2458922F0D0ACA6"
+
+    // WHEN the transaction blob is converted to a hash.
+    let transactionHash = Utils.toTransactionHash(transactionBlobHex: transactionBlobHex)
+
+    // THEN the transaction blob is as expected.
+    XCTAssertEqual(
+      transactionHash,
+      "7B9F6E019C2A79857427B4EF968D77D683AC84F5A880830955D7BDF47F120667"
+    )
+  }
+
+  func testToTransactionHashInvalidTransaction() {
+    // GIVEN an invalid transaction blob.
+    let transactionBlobHex = "xrp"
+
+    // WHEN the transaction blob is converted to a hash.
+    let transactionHash = Utils.toTransactionHash(transactionBlobHex: transactionBlobHex)
+
+    // THEN the hash is nil.
+    XCTAssertNil(transactionHash)
+  }
 }

--- a/Tests/XpringClientTest.swift
+++ b/Tests/XpringClientTest.swift
@@ -25,9 +25,9 @@ final class XpringClientTest: XCTestCase {
 		}
 	}
 
-	static let engineResultCode: Int64 = 0
+	static let transactionBlobHex = "DEADBEEF"
 	static let submitTransactionResponse = Io_Xpring_SubmitSignedTransactionResponse.with {
-		$0.engineResultCode = engineResultCode
+		$0.transactionBlob = transactionBlobHex
 	}
 
 	// MARK: - Balance
@@ -77,7 +77,7 @@ final class XpringClientTest: XCTestCase {
 
 		// WHEN XRP is sent.
 		guard
-			let result = try? xpringClient.send(
+			let transactionHash = try? xpringClient.send(
 				XpringClientTest.sendAmount,
 				to: XpringClientTest.destinationAddress,
 				from: XpringClientTest.wallet)
@@ -87,7 +87,7 @@ final class XpringClientTest: XCTestCase {
 		}
 
 		// THEN the engine result code is as expected.
-		XCTAssertEqual(result.engineResultCode, XpringClientTest.engineResultCode)
+    XCTAssertEqual(transactionHash, Utils.toTransactionHash(transactionBlobHex: XpringClientTest.transactionBlobHex))
 	}
 
 	func testSendWithAccountInfoFailure() {

--- a/XpringKit/Address.swift
+++ b/XpringKit/Address.swift
@@ -1,5 +1,5 @@
 import Foundation
 
-// An address in the Ripple ecosystem. Either an X-Address or a classic address.
+/// An address in the Ripple ecosystem. Either an X-Address or a classic address.
 /// - SeeAlso: https://xrpaddress.info/
 public typealias Address = String

--- a/XpringKit/Hex.swift
+++ b/XpringKit/Hex.swift
@@ -1,3 +1,4 @@
 import Foundation
 
+/// A string which is only composed of hexadecimal characters. 
 public typealias Hex = String

--- a/XpringKit/JavaScript/JavaScriptUtils.swift
+++ b/XpringKit/JavaScript/JavaScriptUtils.swift
@@ -12,6 +12,7 @@ internal class JavaScriptUtils {
     public static let isValidClassicAddress = "isValidClassicAddress"
     public static let isValidXAddress = "isValidXAddress"
     public static let tag = "tag"
+    public static let transactionBlobToTransactionHash = "transactionBlobToTransactionHash"
     public static let utils = "Utils"
   }
 
@@ -21,6 +22,7 @@ internal class JavaScriptUtils {
   private let isValidAddressFunction: JSValue
   private let isValidClassicAddressFunction: JSValue
   private let isValidXAddressFunction: JSValue
+  private let transactionBlobToTransactionHashFunction: JSValue
 
   /// Initialize a JavaScriptUtils object.
   public init() {
@@ -32,6 +34,7 @@ internal class JavaScriptUtils {
     isValidAddressFunction = XRPJavaScriptLoader.load(ResourceNames.isValidAddress, from: utils)
     isValidClassicAddressFunction = XRPJavaScriptLoader.load(ResourceNames.isValidClassicAddress, from: utils)
     isValidXAddressFunction = XRPJavaScriptLoader.load(ResourceNames.isValidXAddress, from: utils)
+    transactionBlobToTransactionHashFunction = XRPJavaScriptLoader.load(ResourceNames.transactionBlobToTransactionHash, from: utils)
   }
 
   /// Check if the given address is a valid XRP address.
@@ -102,5 +105,17 @@ internal class JavaScriptUtils {
       return (classicAddress, tag.toUInt32())
     }
     return (classicAddress, nil)
+  }
+
+  /// Convert the given transaction blob to a transaction hash.
+  ///
+  /// - Parameter transactionBlobHex: A hexadecimal encoded transaction blob.
+  /// - Returns: A hex encoded hash if the input was valid, otherwise undefined.
+  public func toTransactionHash(transactionBlobHex: Hex) -> Hex? {
+    let result = transactionBlobToTransactionHashFunction.call(withArguments: [transactionBlobHex])!
+    guard !result.isUndefined else {
+        return nil
+    }
+    return result.toString()
   }
 }

--- a/XpringKit/TransactionHash.swift
+++ b/XpringKit/TransactionHash.swift
@@ -1,0 +1,2 @@
+/// A hash of a transaction on the XRP Ledger. Hashes are hex encoded strings.
+public typealias TransactionHash = Hex

--- a/XpringKit/Utils.swift
+++ b/XpringKit/Utils.swift
@@ -54,4 +54,12 @@ public enum Utils {
   public static func decode(xAddress: Address) -> (classicAddress: String, tag: UInt32?)? {
     return javaScriptUtils.decode(xAddress: xAddress)
   }
+
+  /// Convert the given transaction blob to a transaction hash.
+  ///
+  /// - Parameter transactionBlobHex: A hexadecimal encoded transaction blob.
+  /// - Returns: A hex encoded hash if the input was valid, otherwise undefined.
+  public static func toTransactionHash(transactionBlobHex: Hex) -> Hex? {
+    return javaScriptUtils.toTransactionHash(transactionBlobHex: transactionBlobHex)
+  }
 }

--- a/XpringKit/XRPLedgerError.swift
+++ b/XpringKit/XRPLedgerError.swift
@@ -2,4 +2,6 @@
 public enum XRPLedgerError: Error {
 	/// A problem occurred while performing the cryptographic signing process.
 	case signingError
+
+  case unknown(String)
 }

--- a/XpringKit/XpringClient.swift
+++ b/XpringKit/XpringClient.swift
@@ -36,8 +36,8 @@ public class XpringClient {
 	///		- destinationAddress: The address which will receive the XRP.
 	///		- sourceWallet: The wallet sending the XRP.
 	/// - Throws: An error if there was a problem communicating with the XRP Ledger.
-	/// - Returns: A response from the ledger.
-	public func send(_ amount: Io_Xpring_XRPAmount, to destinationAddress: Address, from sourceWallet: Wallet) throws -> Io_Xpring_SubmitSignedTransactionResponse {
+	/// - Returns: A transaction hash for the submitted transaction.
+	public func send(_ amount: Io_Xpring_XRPAmount, to destinationAddress: Address, from sourceWallet: Wallet) throws -> TransactionHash {
 		let accountInfo = try getAccountInfo(for: sourceWallet.address)
 		let fee = try getFee()
 
@@ -60,7 +60,11 @@ public class XpringClient {
 			$0.signedTransaction = signedTransaction
 		}
 
-		return try networkClient.submitSignedTransaction(submitSignedTransactionRequest)
+		let submitTransactionResponse = try networkClient.submitSignedTransaction(submitSignedTransactionRequest)
+    guard let hash = Utils.toTransactionHash(transactionBlobHex: submitTransactionResponse.transactionBlob) else {
+      throw XRPLedgerError.unknown("Could not hash transaction blob: \(submitTransactionResponse.transactionBlob)")
+    }
+    return hash
 	}
 
 	/// Retrieve the current fee to submit a transaction to the XRP Ledger.


### PR DESCRIPTION
Protocol buffers are hard for external developers to grok. Rather than returning a protocol buffer response from the gRPC API, return a simple string representing the transaction hash. 

Developers can then use this transaction hash as a token with which to monitor or reference the transaction in the future. 

This change is a breaking API change, and the library will get versioned accordingly.

Note: I will likely update the documentation in one fell swoop and get a proper review from a tech writer. These APIs aren't accessible until I cut a new release and I'd like the README to reflect what artifacts are currently published.