### PR TITLE
Tx hash return

### DIFF
--- a/Tests/XpringClientTest.swift
+++ b/Tests/XpringClientTest.swift
@@ -25,9 +25,9 @@ final class XpringClientTest: XCTestCase {
 		}
 	}
 
-	static let engineResultCode: Int64 = 0
+	static let transactionBlobHex = "DEADBEEF"
 	static let submitTransactionResponse = Io_Xpring_SubmitSignedTransactionResponse.with {
-		$0.engineResultCode = engineResultCode
+		$0.transactionBlob = transactionBlobHex
 	}
 
 	// MARK: - Balance
@@ -77,7 +77,7 @@ final class XpringClientTest: XCTestCase {
 
 		// WHEN XRP is sent.
 		guard
-			let result = try? xpringClient.send(
+			let transactionHash = try? xpringClient.send(
 				XpringClientTest.sendAmount,
 				to: XpringClientTest.destinationAddress,
 				from: XpringClientTest.wallet)
@@ -87,7 +87,7 @@ final class XpringClientTest: XCTestCase {
 		}
 
 		// THEN the engine result code is as expected.
-		XCTAssertEqual(result.engineResultCode, XpringClientTest.engineResultCode)
+    XCTAssertEqual(transactionHash, Utils.toTransactionHash(transactionBlobHex: XpringClientTest.transactionBlobHex))
 	}
 
 	func testSendWithAccountInfoFailure() {

--- a/XpringKit/Address.swift
+++ b/XpringKit/Address.swift
@@ -1,5 +1,5 @@
 import Foundation
 
-// An address in the Ripple ecosystem. Either an X-Address or a classic address.
+/// An address in the Ripple ecosystem. Either an X-Address or a classic address.
 /// - SeeAlso: https://xrpaddress.info/
 public typealias Address = String

--- a/XpringKit/Hex.swift
+++ b/XpringKit/Hex.swift
@@ -1,3 +1,4 @@
 import Foundation
 
+/// A string which is only composed of hexadecimal characters. 
 public typealias Hex = String

--- a/XpringKit/TransactionHash.swift
+++ b/XpringKit/TransactionHash.swift
@@ -1,0 +1,2 @@
+/// A hash of a transaction on the XRP Ledger. Hashes are hex encoded strings.
+public typealias TransactionHash = Hex

--- a/XpringKit/XRPLedgerError.swift
+++ b/XpringKit/XRPLedgerError.swift
@@ -2,4 +2,6 @@
 public enum XRPLedgerError: Error {
 	/// A problem occurred while performing the cryptographic signing process.
 	case signingError
+
+  case unknown(String)
 }

--- a/XpringKit/XpringClient.swift
+++ b/XpringKit/XpringClient.swift
@@ -36,8 +36,8 @@ public class XpringClient {
 	///		- destinationAddress: The address which will receive the XRP.
 	///		- sourceWallet: The wallet sending the XRP.
 	/// - Throws: An error if there was a problem communicating with the XRP Ledger.
-	/// - Returns: A response from the ledger.
-	public func send(_ amount: Io_Xpring_XRPAmount, to destinationAddress: Address, from sourceWallet: Wallet) throws -> Io_Xpring_SubmitSignedTransactionResponse {
+	/// - Returns: A transaction hash for the submitted transaction.
+	public func send(_ amount: Io_Xpring_XRPAmount, to destinationAddress: Address, from sourceWallet: Wallet) throws -> TransactionHash {
 		let accountInfo = try getAccountInfo(for: sourceWallet.address)
 		let fee = try getFee()
 
@@ -60,7 +60,11 @@ public class XpringClient {
 			$0.signedTransaction = signedTransaction
 		}
 
-		return try networkClient.submitSignedTransaction(submitSignedTransactionRequest)
+		let submitTransactionResponse = try networkClient.submitSignedTransaction(submitSignedTransactionRequest)
+    guard let hash = Utils.toTransactionHash(transactionBlobHex: submitTransactionResponse.transactionBlob) else {
+      throw XRPLedgerError.unknown("Could not hash transaction blob: \(submitTransactionResponse.transactionBlob)")
+    }
+    return hash
 	}
 
 	/// Retrieve the current fee to submit a transaction to the XRP Ledger.


### PR DESCRIPTION
Protocol buffers are hard for external developers to grok. Rather than returning a protocol buffer response from the gRPC API, return a simple string representing the transaction hash.

Developers can then use this transaction hash as a token with which to monitor or reference the transaction in the future.

This change is a breaking API change, and the library will get versioned accordingly.

Note: I will likely update the documentation in one fell swoop and get a proper review from a tech writer. These APIs aren't accessible until I cut a new release and I'd like the README to reflect what artifacts are currently published.