### PR TITLE
Add Transaction Status API

### DIFF
--- a/Tests/Fakes/FakeNetworkClient.swift
+++ b/Tests/Fakes/FakeNetworkClient.swift
@@ -14,22 +14,29 @@ public class FakeNetworkClient {
   /// Result of a call to getLatestValidatedLedgerSequence.
   private let latestValidatedLedgerSequenceResult: Result<Io_Xpring_LedgerSequence, Error>
 
+  /// Result of a call to getTransactionStatus.
+  private let transactionStatusResult: Result<Io_Xpring_TransactionStatus, Error>
+
 	/// Initialize a new fake NetworkClient.
 	///
-	/// - Parameter accountInfoResult: A result which will be used to determine the behavior of getAccountInfo().
-	/// - Parameter feeResult: A result which will be used to determine the behavior of getFee().
-	/// - Parameter submitSignedTransactionResult: A result which will be used to determine the behavior of submitSignedTransaction().
-  /// - Parameter latestValidatedLedgerSequenceResult: A result which will be used to determine behavior of getLatestValidatedLedgerSequence().
+	/// - Parameters:
+  ///   - accountInfoResult: A result which will be used to determine the behavior of getAccountInfo().
+	///   - feeResult: A result which will be used to determine the behavior of getFee().
+	///   - submitSignedTransactionResult: A result which will be used to determine the behavior of submitSignedTransaction().
+  ///   - latestValidatedLedgerSequenceResult: A result which will be used to determine behavior of getLatestValidatedLedgerSequence().
+  ///   - transactionStatusResult: A result which will be used to determine behavior of getTransactionStatus().
   public init(
     accountInfoResult: Result<Io_Xpring_AccountInfo, Error>,
     feeResult: Result<Io_Xpring_Fee, Error>,
     submitSignedTransactionResult: Result<Io_Xpring_SubmitSignedTransactionResponse, Error>,
-    latestValidatedLedgerSequenceResult: Result<Io_Xpring_LedgerSequence, Error>
+    latestValidatedLedgerSequenceResult: Result<Io_Xpring_LedgerSequence, Error>,
+    transactionStatusResult: Result<Io_Xpring_TransactionStatus, Error>
   ) {
     self.accountInfoResult = accountInfoResult
     self.feeResult = feeResult
     self.submitSignedTransactionResult = submitSignedTransactionResult
     self.latestValidatedLedgerSequenceResult = latestValidatedLedgerSequenceResult
+    self.transactionStatusResult = transactionStatusResult
   }
 }
 
@@ -64,6 +71,15 @@ extension FakeNetworkClient: NetworkClient {
 
   public func getLatestValidatedLedgerSequence(_ request: Io_Xpring_GetLatestValidatedLedgerSequenceRequest) throws -> Io_Xpring_LedgerSequence {
     switch latestValidatedLedgerSequenceResult {
+    case .success(let result):
+      return result
+    case .failure(let error):
+      throw error
+    }
+  }
+
+  public func getTransactionStatus(_ request: Io_Xpring_GetTransactionStatusRequest) throws -> Io_Xpring_TransactionStatus {
+    switch transactionStatusResult {
     case .success(let result):
       return result
     case .failure(let error):

--- a/Tests/IntegrationTests.swift
+++ b/Tests/IntegrationTests.swift
@@ -20,6 +20,10 @@ extension BigUInt {
   public static let drops = BigUInt(1)
 }
 
+extension TransactionHash {
+  public static let successfulTransactionHash = "2CBBD2523478848DA256F8EBFCBD490DD6048A4A5094BF8E3034F57EA6AA0522"
+}
+
 /// Integration tests run against a live remote client.
 final class IntegrationTests: XCTestCase {
   private let client = XpringClient(grpcURL: .remoteURL)
@@ -37,6 +41,15 @@ final class IntegrationTests: XCTestCase {
       _ = try client.send(.drops, to: .recipientAddress, from: .testWallet)
     } catch {
       XCTFail("Failed sending XRP with error: \(error)")
+    }
+  }
+  
+  func testGetTransactionStatus() {
+    do {
+      let transactionStatus = try client.getTransactionStatus(for: .successfulTransactionHash)
+      XCTAssertEqual(transactionStatus, .succeeded)
+    } catch {
+      XCTFail("Failed retrieving transaction hash with error: \(error)");
     }
   }
 }

--- a/Tests/XpringClientTest.swift
+++ b/Tests/XpringClientTest.swift
@@ -7,8 +7,8 @@ extension TransactionHash {
 }
 
 extension String {
-  public static let transactionStatusCodeSuccess = "tesSuccess"
-  public static let transactionStatusCodeFailure = "tecFailure"
+  public static let transactionStatusCodeSuccess = "tesSUCCESS"
+  public static let transactionStatusCodeFailure = "tecFAILURE"
 }
 
 extension Io_Xpring_TransactionStatus {
@@ -226,8 +226,8 @@ final class XpringClientTest: XCTestCase {
 		))
 	}
 
-  func testGetTransactionStatusWithInvalidatedTransactionAndFailureCode() {
-    // GIVEN a XpringClient which returns an invalidated transaction and a failed transaction status code.
+  func testGetTransactionStatusWithUnvalidatedTransactionAndFailureCode() {
+    // GIVEN a XpringClient which returns an unvalidated transaction and a failed transaction status code.
     let transactionStatusResponse = Io_Xpring_TransactionStatus.with {
       $0.validated = false
       $0.transactionStatusCode = .transactionStatusCodeFailure
@@ -248,8 +248,8 @@ final class XpringClientTest: XCTestCase {
     XCTAssertEqual(transactionStatus, .pending)
   }
 
-  func testGetTransactionStatusWithInvalidatedTransactionAndSuccessCode() {
-    // GIVEN a XpringClient which returns an invalidated transaction and a succeeded transaction status code.
+  func testGetTransactionStatusWithUnvalidatedTransactionAndSuccessCode() {
+    // GIVEN a XpringClient which returns an unvalidated transaction and a succeeded transaction status code.
     let transactionStatusResponse = Io_Xpring_TransactionStatus.with {
       $0.validated = false
       $0.transactionStatusCode = .transactionStatusCodeSuccess

--- a/Tests/XpringClientTest.swift
+++ b/Tests/XpringClientTest.swift
@@ -2,6 +2,22 @@ import BigInt
 import XCTest
 @testable import XpringKit
 
+extension TransactionHash {
+  public static let transactionHash = "DEADBEEF"
+}
+
+extension String {
+  public static let transactionStatusCodeSuccess = "tesSuccess"
+  public static let transactionStatusCodeFailure = "tecFailure"
+}
+
+extension Io_Xpring_TransactionStatus {
+  public static let transactionStatus = Io_Xpring_TransactionStatus.with {
+    $0.validated = true
+    $0.transactionStatusCode = .transactionStatusCodeSuccess
+  }
+}
+
 final class XpringClientTest: XCTestCase {
 	static let wallet = Wallet(seed: "snYP7oArxKepd3GPDcrjMsJYiJeJB")!
 	static let destinationAddress = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUFyQVMzRrMGUZpokKH"
@@ -37,7 +53,8 @@ final class XpringClientTest: XCTestCase {
     accountInfoResult: .success(XpringClientTest.accountInfo),
     feeResult: .success(XpringClientTest.fee),
     submitSignedTransactionResult: .success(XpringClientTest.submitTransactionResponse),
-    latestValidatedLedgerSequenceResult: .success(XpringClientTest.ledgerSequence)
+    latestValidatedLedgerSequenceResult: .success(XpringClientTest.ledgerSequence),
+    transactionStatusResult: .success(.transactionStatus)
   )
 
 	// MARK: - Balance
@@ -74,7 +91,8 @@ final class XpringClientTest: XCTestCase {
 			accountInfoResult: .failure(XpringKitTestError.mockFailure),
 			feeResult: .success(XpringClientTest.fee),
       submitSignedTransactionResult: .success(XpringClientTest.submitTransactionResponse),
-      latestValidatedLedgerSequenceResult: .success(XpringClientTest.ledgerSequence)
+      latestValidatedLedgerSequenceResult: .success(XpringClientTest.ledgerSequence),
+      transactionStatusResult: .success(.transactionStatus)
 		)
 		let xpringClient = XpringClient(networkClient: networkClient)
 
@@ -138,7 +156,8 @@ final class XpringClientTest: XCTestCase {
 			accountInfoResult: .failure(XpringKitTestError.mockFailure),
 			feeResult: .success(XpringClientTest.fee),
 			submitSignedTransactionResult: .success(XpringClientTest.submitTransactionResponse),
-      latestValidatedLedgerSequenceResult: .success(XpringClientTest.ledgerSequence)
+      latestValidatedLedgerSequenceResult: .success(XpringClientTest.ledgerSequence),
+      transactionStatusResult: .success(.transactionStatus)
 		)
 		let xpringClient = XpringClient(networkClient: networkClient)
 
@@ -156,7 +175,8 @@ final class XpringClientTest: XCTestCase {
 			accountInfoResult: .success(XpringClientTest.accountInfo),
 			feeResult: .failure(XpringKitTestError.mockFailure),
 			submitSignedTransactionResult: .success(XpringClientTest.submitTransactionResponse),
-      latestValidatedLedgerSequenceResult: .success(XpringClientTest.ledgerSequence)
+      latestValidatedLedgerSequenceResult: .success(XpringClientTest.ledgerSequence),
+      transactionStatusResult: .success(.transactionStatus)
 		)
 		let xpringClient = XpringClient(networkClient: networkClient)
 
@@ -174,7 +194,8 @@ final class XpringClientTest: XCTestCase {
       accountInfoResult: .success(XpringClientTest.accountInfo),
       feeResult: .success(XpringClientTest.fee),
       submitSignedTransactionResult: .success(XpringClientTest.submitTransactionResponse),
-      latestValidatedLedgerSequenceResult: .failure(XpringKitTestError.mockFailure)
+      latestValidatedLedgerSequenceResult: .failure(XpringKitTestError.mockFailure),
+      transactionStatusResult: .success(.transactionStatus)
     )
     let xpringClient = XpringClient(networkClient: networkClient)
 
@@ -192,15 +213,119 @@ final class XpringClientTest: XCTestCase {
 			accountInfoResult: .success(XpringClientTest.accountInfo),
 			feeResult: .success(XpringClientTest.fee),
 			submitSignedTransactionResult: .failure(XpringKitTestError.mockFailure),
-      latestValidatedLedgerSequenceResult: .success(XpringClientTest.ledgerSequence)
+      latestValidatedLedgerSequenceResult: .success(XpringClientTest.ledgerSequence),
+      transactionStatusResult: .success(.transactionStatus)
 		)
 		let xpringClient = XpringClient(networkClient: networkClient)
 
-		// WHEN a send is attempted then an error is thrown.
+		// WHEN a send is attempted THEN an error is thrown.
 		XCTAssertThrowsError(try xpringClient.send(
 			XpringClientTest.sendAmount,
 			to: XpringClientTest.destinationAddress,
 			from: XpringClientTest.wallet
 		))
 	}
+
+  func testGetTransactionStatusWithInvalidatedTransactionAndFailureCode() {
+    // GIVEN a XpringClient which returns an invalidated transaction and a failed transaction status code.
+    let transactionStatusResponse = Io_Xpring_TransactionStatus.with {
+      $0.validated = false
+      $0.transactionStatusCode = .transactionStatusCodeFailure
+    }
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .success(XpringClientTest.accountInfo),
+      feeResult: .success(XpringClientTest.fee),
+      submitSignedTransactionResult: .success(XpringClientTest.submitTransactionResponse),
+      latestValidatedLedgerSequenceResult: .success(XpringClientTest.ledgerSequence),
+      transactionStatusResult: .success(transactionStatusResponse)
+    )
+    let xpringClient = XpringClient(networkClient: networkClient)
+
+    // WHEN the transaction status is retrieved.
+    let transactionStatus = try? xpringClient.getTransactionStatus(for: .transactionHash)
+
+    // THEN the transaction status is pending.
+    XCTAssertEqual(transactionStatus, .pending)
+  }
+
+  func testGetTransactionStatusWithInvalidatedTransactionAndSuccessCode() {
+    // GIVEN a XpringClient which returns an invalidated transaction and a succeeded transaction status code.
+    let transactionStatusResponse = Io_Xpring_TransactionStatus.with {
+      $0.validated = false
+      $0.transactionStatusCode = .transactionStatusCodeSuccess
+    }
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .success(XpringClientTest.accountInfo),
+      feeResult: .success(XpringClientTest.fee),
+      submitSignedTransactionResult: .success(XpringClientTest.submitTransactionResponse),
+      latestValidatedLedgerSequenceResult: .success(XpringClientTest.ledgerSequence),
+      transactionStatusResult: .success(transactionStatusResponse)
+    )
+    let xpringClient = XpringClient(networkClient: networkClient)
+
+    // WHEN the transaction status is retrieved.
+    let transactionStatus = try? xpringClient.getTransactionStatus(for: .transactionHash)
+
+    // THEN the transaction status is pending.
+    XCTAssertEqual(transactionStatus, .pending)
+  }
+
+  func testGetTransactionStatusWithValidatedTransactionAndFailureCode() {
+    // GIVEN a XpringClient which returns a validated transaction and a failed transaction status code.
+    let transactionStatusResponse = Io_Xpring_TransactionStatus.with {
+      $0.validated = true
+      $0.transactionStatusCode = .transactionStatusCodeFailure
+    }
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .success(XpringClientTest.accountInfo),
+      feeResult: .success(XpringClientTest.fee),
+      submitSignedTransactionResult: .success(XpringClientTest.submitTransactionResponse),
+      latestValidatedLedgerSequenceResult: .success(XpringClientTest.ledgerSequence),
+      transactionStatusResult: .success(transactionStatusResponse)
+    )
+    let xpringClient = XpringClient(networkClient: networkClient)
+
+    // WHEN the transaction status is retrieved.
+    let transactionStatus = try? xpringClient.getTransactionStatus(for: .transactionHash)
+
+    // THEN the transaction status is failed.
+    XCTAssertEqual(transactionStatus, .failed)
+  }
+
+  func testGetTransactionStatusWithValidatedTransactionAndSuccessCode() {
+    // GIVEN a XpringClient which returns a validated transaction and a succeeded transaction status code.
+    let transactionStatusResponse = Io_Xpring_TransactionStatus.with {
+      $0.validated = true
+      $0.transactionStatusCode = .transactionStatusCodeSuccess
+    }
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .success(XpringClientTest.accountInfo),
+      feeResult: .success(XpringClientTest.fee),
+      submitSignedTransactionResult: .success(XpringClientTest.submitTransactionResponse),
+      latestValidatedLedgerSequenceResult: .success(XpringClientTest.ledgerSequence),
+      transactionStatusResult: .success(transactionStatusResponse)
+    )
+    let xpringClient = XpringClient(networkClient: networkClient)
+
+    // WHEN the transaction status is retrieved.
+    let transactionStatus = try? xpringClient.getTransactionStatus(for: .transactionHash)
+
+    // THEN the transaction status is succeeded.
+    XCTAssertEqual(transactionStatus, .succeeded)
+  }
+
+  func testGetTransactionStatusWithServerFailure() {
+    // GIVEN a XpringClient which fails to return a transaction status.
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .success(XpringClientTest.accountInfo),
+      feeResult: .success(XpringClientTest.fee),
+      submitSignedTransactionResult: .success(XpringClientTest.submitTransactionResponse),
+      latestValidatedLedgerSequenceResult: .success(XpringClientTest.ledgerSequence),
+      transactionStatusResult: .failure(XpringKitTestError.mockFailure)
+    )
+    let xpringClient = XpringClient(networkClient: networkClient)
+
+    // WHEN the transaction status is retrieved THEN an error is thrown.
+    XCTAssertThrowsError(try xpringClient.getTransactionStatus(for: .transactionHash))
+  }
 }

--- a/XpringKit.xcodeproj/project.pbxproj
+++ b/XpringKit.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		7B54EC43CDEB457E0A065ED2 /* IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42C1A6AD7B7AC4F5483751E /* IntegrationTests.swift */; };
 		7B9ADCFF14AF87E6751F8E46 /* Address+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = B26D12954276D34124999E61 /* Address+Test.swift */; };
 		7DA4A6E51E3AFAFBED32306F /* currency.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BEFEBC1AAB0132A6C7440B /* currency.pb.swift */; };
+		7F29A55A5EE4CB4A41C73E2B /* TransactionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBB02CC192CD7AE7E3218E98 /* TransactionStatus.swift */; };
 		81696621C0B84D6070610A93 /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E488ABD93CCADA4769887E2 /* SwiftProtobuf.framework */; };
 		81C5E3886C4126C4CF497F8B /* ByteArray+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DD77F8CDC039E5870305B91 /* ByteArray+Hex.swift */; };
 		8665AF97EFA52EE4A094CAC6 /* get_latest_validated_ledger_sequence_request.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFD34F71A81FED319AFC579E /* get_latest_validated_ledger_sequence_request.pb.swift */; };
@@ -80,6 +81,7 @@
 		8D18C4538BFC9A307CD4659E /* BigInt.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3E837E32019F19EDE7F76CC /* BigInt.framework */; };
 		8E20C020282A1D047B37D006 /* ledger_sequence.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56D70978C361F6E73333A5E /* ledger_sequence.pb.swift */; };
 		8FC35678AE62B871ABB68F4F /* JSValue+JavaScriptWallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A8DF813EA75BD18BE4F7E7 /* JSValue+JavaScriptWallet.swift */; };
+		952227251108B99C69F0EEBE /* TransactionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBB02CC192CD7AE7E3218E98 /* TransactionStatus.swift */; };
 		989315F8E85E2F007A4B37D5 /* fiat_amount.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D388B81E54EFF183B52C96B /* fiat_amount.pb.swift */; };
 		99A0B0264D9AED1A071597E0 /* xrp_amount.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD81AC2984EC4A639432DD2A /* xrp_amount.pb.swift */; };
 		99C1C3D26CE29D9EBF964776 /* SwiftGRPC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B776589D95D938D60AB4917C /* SwiftGRPC.framework */; };
@@ -218,6 +220,7 @@
 		C1D0F50AF49F103E1E0B3D50 /* UtilsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilsTest.swift; sourceTree = "<group>"; };
 		C90607EA7652B0A5C9E360F6 /* get_transaction_status_request.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = get_transaction_status_request.pb.swift; sourceTree = "<group>"; };
 		C987E39201D5B0AA9E73428E /* Signer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Signer.swift; sourceTree = "<group>"; };
+		CBB02CC192CD7AE7E3218E98 /* TransactionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionStatus.swift; sourceTree = "<group>"; };
 		CC429E0E63319A1BE3AE8240 /* JavaScriptSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JavaScriptSerializer.swift; sourceTree = "<group>"; };
 		CFA89B2B4CE85050623E1F1A /* Wallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Wallet.swift; sourceTree = "<group>"; };
 		CFD34F71A81FED319AFC579E /* get_latest_validated_ledger_sequence_request.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = get_latest_validated_ledger_sequence_request.pb.swift; sourceTree = "<group>"; };
@@ -324,6 +327,7 @@
 				ACC165482A69C013773E743E /* RippledServiceClient+NetworkClient.swift */,
 				C987E39201D5B0AA9E73428E /* Signer.swift */,
 				FB2C2BF0895DEDD1C9AB5D2D /* TransactionHash.swift */,
+				CBB02CC192CD7AE7E3218E98 /* TransactionStatus.swift */,
 				BC9FE3C197FEAD7C98B45EAC /* Utils.swift */,
 				CFA89B2B4CE85050623E1F1A /* Wallet.swift */,
 				ADD0BDE0881A1C6DDE6D939A /* WalletGenerationResult.swift */,
@@ -621,6 +625,7 @@
 				1E6AFE0AF006DE4A93E6C447 /* RippledServiceClient+NetworkClient.swift in Sources */,
 				3290ACBFC35352A9E8A83C27 /* Signer.swift in Sources */,
 				4060097AAC967721CFA653BB /* TransactionHash.swift in Sources */,
+				952227251108B99C69F0EEBE /* TransactionStatus.swift in Sources */,
 				9C4F498B7586CE1B089E587A /* Utils.swift in Sources */,
 				2E74A8B58BC16DD3EBD77AE3 /* Wallet.swift in Sources */,
 				DB26AC6D896AF31860B1CCE8 /* WalletGenerationResult.swift in Sources */,
@@ -699,6 +704,7 @@
 				138FBD4E100E3D90656346EB /* RippledServiceClient+NetworkClient.swift in Sources */,
 				6933342C51E08FAFA80E5244 /* Signer.swift in Sources */,
 				79FD2BD66600BDE782DE7C0A /* TransactionHash.swift in Sources */,
+				7F29A55A5EE4CB4A41C73E2B /* TransactionStatus.swift in Sources */,
 				C96B86F7E67405016867D3EC /* Utils.swift in Sources */,
 				3D64D171483F28464E621B42 /* Wallet.swift in Sources */,
 				2DFB7C1BCA54ED07FCEE083A /* WalletGenerationResult.swift in Sources */,

--- a/XpringKit/NetworkClient.swift
+++ b/XpringKit/NetworkClient.swift
@@ -27,4 +27,11 @@ public protocol NetworkClient {
   /// - Throws: An error if there was a problem communicating with the XRP Ledger.
   /// - Returns: A  `LedgerSequence` object which contains the index.
   func getLatestValidatedLedgerSequence(_ request: Io_Xpring_GetLatestValidatedLedgerSequenceRequest) throws -> Io_Xpring_LedgerSequence
+
+  /// Retrieve transaction status for a given transaction hash from the XRP Ledger.
+  ///
+  /// - Parameter request: Request parameters for retrieving transaction status.
+  /// - Throws: An error if there was a problem communicating with the XRP Ledger.
+  /// - Returns: A `TransactionStatus`  for the transactioon.
+  func getTransactionStatus(_ request: Io_Xpring_GetTransactionStatusRequest) throws -> Io_Xpring_TransactionStatus
 }

--- a/XpringKit/TransactionStatus.swift
+++ b/XpringKit/TransactionStatus.swift
@@ -1,0 +1,14 @@
+/// Represents statuses of transactions.
+public enum TransactionStatus {
+  // The transaction was included in a finalized ledger and failed.
+  case failed
+
+  // The transaction is not included in a finalized ledger.
+  case pending
+
+  // The transaction was included in a finalized ledger and succeeded.
+  case succeeded
+
+  // The transaction status is unknown.
+  case unknown
+}

--- a/XpringKit/XpringClient.swift
+++ b/XpringKit/XpringClient.swift
@@ -37,10 +37,16 @@ public class XpringClient {
     return BigUInt(stringLiteral: accountInfo.balance.drops)
 	}
 
+  /// Retrieve the transaction status for a given transaction hash.
+  ///
+  /// - Parameter transactionHash: The hash of the transaction.
+  /// - Throws: An error if there was a problem communicating with the XRP Ledger.
+  /// - Returns: The status of the given transaction.
   public func getTransactionStatus(for transactionHash: TransactionHash) throws -> TransactionStatus {
     let transactionStatusRequest = Io_Xpring_GetTransactionStatusRequest.with { $0.transactionHash = transactionHash }
     let transactionStatus = try networkClient.getTransactionStatus(transactionStatusRequest)
 
+    // Return pending if the transaction is not validated.
     guard transactionStatus.validated else {
       return .pending
     }

--- a/XpringKit/XpringClient.swift
+++ b/XpringKit/XpringClient.swift
@@ -37,6 +37,16 @@ public class XpringClient {
     return BigUInt(stringLiteral: accountInfo.balance.drops)
 	}
 
+  public func getTransactionStatus(for transactionHash: TransactionHash) throws -> TransactionStatus {
+    let transactionStatusRequest = Io_Xpring_GetTransactionStatusRequest.with { $0.transactionHash = transactionHash }
+    let transactionStatus = try networkClient.getTransactionStatus(transactionStatusRequest)
+
+    guard transactionStatus.validated else {
+      return .pending
+    }
+    return transactionStatus.transactionStatusCode.starts(with: "tes") ? .succeeded : .failed
+  }
+
 	/// Send XRP to a recipient on the XRP Ledger.
 	///
 	/// - Parameters:


### PR DESCRIPTION
Code Changes:
- Wire RPC for getTransactionStatus
- Add enum for Transaction Status
- Wire RPC and enum to a new `getTransactionStatus` API

Tested:
- Add unit tests 
- Add integration Tests

This is part of a group of PRs:
- Xpring-JS / JavaScript: https://github.com/xpring-eng/Xpring-JS/pull/77
- Xpring4J / Java: https://github.com/xpring-eng/xpring4j/pull/44
- XpringKit / Swift: https://github.com/xpring-eng/XpringKit/pull/40

Note: Integration tests failing until the Appian node wrapper is updated. PR is here: https://github.com/xpring-eng/AppianJS/pull/29