### PR TITLE
Reliable Transaction Submission

### DIFF
--- a/Tests/DefaultXpringClientTest.swift
+++ b/Tests/DefaultXpringClientTest.swift
@@ -73,10 +73,6 @@ extension Io_Xpring_TransactionStatus {
   }
 }
 
-extension TransactionHash {
-  public static let transactionHash = "DEADBEEF"
-}
-
 final class DefaultXpringClientTest: XCTestCase {
   // MARK: - Balance
 
@@ -259,7 +255,7 @@ final class DefaultXpringClientTest: XCTestCase {
     let xpringClient = DefaultXpringClient(networkClient: networkClient)
 
     // WHEN the transaction status is retrieved.
-    let transactionStatus = try? xpringClient.getTransactionStatus(for: .transactionHash)
+    let transactionStatus = try? xpringClient.getTransactionStatus(for: .testTransactionHash)
 
     // THEN the transaction status is pending.
     XCTAssertEqual(transactionStatus, .pending)
@@ -281,7 +277,7 @@ final class DefaultXpringClientTest: XCTestCase {
     let xpringClient = DefaultXpringClient(networkClient: networkClient)
 
     // WHEN the transaction status is retrieved.
-    let transactionStatus = try? xpringClient.getTransactionStatus(for: .transactionHash)
+    let transactionStatus = try? xpringClient.getTransactionStatus(for: .testTransactionHash)
 
     // THEN the transaction status is pending.
     XCTAssertEqual(transactionStatus, .pending)
@@ -303,7 +299,7 @@ final class DefaultXpringClientTest: XCTestCase {
     let xpringClient = DefaultXpringClient(networkClient: networkClient)
 
     // WHEN the transaction status is retrieved.
-    let transactionStatus = try? xpringClient.getTransactionStatus(for: .transactionHash)
+    let transactionStatus = try? xpringClient.getTransactionStatus(for: .testTransactionHash)
 
     // THEN the transaction status is failed.
     XCTAssertEqual(transactionStatus, .failed)
@@ -325,7 +321,7 @@ final class DefaultXpringClientTest: XCTestCase {
     let xpringClient = DefaultXpringClient(networkClient: networkClient)
 
     // WHEN the transaction status is retrieved.
-    let transactionStatus = try? xpringClient.getTransactionStatus(for: .transactionHash)
+    let transactionStatus = try? xpringClient.getTransactionStatus(for: .testTransactionHash)
 
     // THEN the transaction status is succeeded.
     XCTAssertEqual(transactionStatus, .succeeded)
@@ -343,6 +339,6 @@ final class DefaultXpringClientTest: XCTestCase {
     let xpringClient = DefaultXpringClient(networkClient: networkClient)
 
     // WHEN the transaction status is retrieved THEN an error is thrown.
-    XCTAssertThrowsError(try xpringClient.getTransactionStatus(for: .transactionHash))
+    XCTAssertThrowsError(try xpringClient.getTransactionStatus(for: .testTransactionHash))
   }
 }

--- a/Tests/Fakes/FakeXpringClient.swift
+++ b/Tests/Fakes/FakeXpringClient.swift
@@ -1,6 +1,8 @@
 import BigInt
 import XpringKit
 
+/// A  fake XpringClient which returns the given iVars as results from XpringClientDecorator calls.
+/// - Note: Since this class is passed by reference and the iVars are mutable, outputs of this class can be changed after it is injected.
 public class FakeXpringClient {
   public let networkClient: NetworkClient = FakeNetworkClient.successfulFakeNetworkClient
 

--- a/Tests/Fakes/FakeXpringClient.swift
+++ b/Tests/Fakes/FakeXpringClient.swift
@@ -1,0 +1,48 @@
+import BigInt
+import XpringKit
+
+public class FakeXpringClient {
+  public let networkClient: NetworkClient = FakeNetworkClient.successfulFakeNetworkClient
+
+  public var getBalanceValue: BigUInt
+  public var transactionStatusValue: TransactionStatus
+  public var sendValue: TransactionHash
+  public var latestValidatedLedgerValue: UInt32
+  public var rawTransactionStatusValue: Io_Xpring_TransactionStatus
+
+  public init(
+    getBalanceValue: BigUInt,
+    transactionStatusValue: TransactionStatus,
+    sendValue: TransactionHash,
+    latestValidatedLedgerValue: UInt32,
+    rawTransactionStatusValue: Io_Xpring_TransactionStatus
+  ) {
+    self.getBalanceValue = getBalanceValue
+    self.transactionStatusValue = transactionStatusValue
+    self.sendValue = sendValue
+    self.latestValidatedLedgerValue = latestValidatedLedgerValue
+    self.rawTransactionStatusValue = rawTransactionStatusValue
+  }
+}
+
+extension FakeXpringClient: XpringClientDecorator {
+  public func getBalance(for address: Address) throws -> BigUInt {
+    return getBalanceValue
+  }
+
+  public func getTransactionStatus(for transactionHash: TransactionHash) throws -> TransactionStatus {
+    return transactionStatusValue
+  }
+
+  public func send(_ amount: BigUInt, to destinationAddress: Address, from sourceWallet: Wallet) throws -> TransactionHash {
+    return sendValue
+  }
+
+  public func getLatestValidatedLedgerSequence() throws -> UInt32 {
+    return latestValidatedLedgerValue
+  }
+
+  public func getRawTransactionStatus(for transactionHash: TransactionHash) throws -> Io_Xpring_TransactionStatus {
+    return rawTransactionStatusValue
+  }
+}

--- a/Tests/Helpers/TransactionHash+Test.swift
+++ b/Tests/Helpers/TransactionHash+Test.swift
@@ -1,0 +1,5 @@
+import XpringKit
+
+extension TransactionHash {
+  public static let testTransactionHash = "DEADBEEF"
+}

--- a/Tests/IntegrationTests.swift
+++ b/Tests/IntegrationTests.swift
@@ -9,7 +9,7 @@ extension Wallet {
 
 extension String {
   /// The URL of the remote gRPC service.
-  public static let remoteURL = "127.0.0.1:3002" // "grpc.xpring.tech:80"
+  public static let remoteURL = "grpc.xpring.tech:80"
 
   /// An address on the chain to receive funds.
   public static let recipientAddress = "X7cBcY4bdTTzk3LHmrKAK6GyrirkXfLHGFxzke5zTmYMfw4"

--- a/Tests/IntegrationTests.swift
+++ b/Tests/IntegrationTests.swift
@@ -9,7 +9,7 @@ extension Wallet {
 
 extension String {
   /// The URL of the remote gRPC service.
-  public static let remoteURL = "grpc.xpring.tech:80"
+  public static let remoteURL = "127.0.0.1:3002" // "grpc.xpring.tech:80"
 
   /// An address on the chain to receive funds.
   public static let recipientAddress = "X7cBcY4bdTTzk3LHmrKAK6GyrirkXfLHGFxzke5zTmYMfw4"

--- a/Tests/ReliableSubmissionXpringClientTest.swift
+++ b/Tests/ReliableSubmissionXpringClientTest.swift
@@ -1,0 +1,113 @@
+import BigInt
+import XCTest
+@testable import XpringKit
+
+final class ReliableSubmissionClientTest: XCTestCase {
+  let defaultBalanceValue = BigUInt(0)
+  let defaultTransactionStatusValue: TransactionStatus = .succeeded
+  let defaultSendValue = "DEADBEEF"
+  let defaultLastestValidatedLedgerValue: UInt32 = 10
+  let defaultRawTransactionStatusValue = Io_Xpring_TransactionStatus.with {
+    $0.validated = true
+    $0.transactionStatusCode = "tesSuccess"
+    $0.lastLedgerSequence = 100
+  }
+
+  var fakeXpringClient: FakeXpringClient!
+  var reliableSubmissionClient: ReliableSubmissionXpringClient!
+
+  override func setUp() {
+    fakeXpringClient = FakeXpringClient(
+      getBalanceValue: defaultBalanceValue,
+      transactionStatusValue: defaultTransactionStatusValue,
+      sendValue: defaultSendValue,
+      latestValidatedLedgerValue: defaultLastestValidatedLedgerValue,
+      rawTransactionStatusValue: defaultRawTransactionStatusValue
+    )
+
+    reliableSubmissionClient = ReliableSubmissionXpringClient(decoratedClient: fakeXpringClient)
+  }
+
+  func testGetBalance() {
+    // GIVEN a `ReliableSubmissionClient` decorating a FakeXpringClient WHEN a balance is retrieved THEN the result is returned unaltered.
+    XCTAssertEqual(try? reliableSubmissionClient.getBalance(for: .testAddress), defaultBalanceValue)
+  }
+
+  func testGetTransactionStatus() {
+    // GIVEN a `ReliableSubmissionClient` decorating a FakeXpringClient WHEN a transaction status is retrieved THEN the result is returned unaltered.
+    XCTAssertEqual(try? reliableSubmissionClient.getTransactionStatus(for: .testTransactionHash), defaultTransactionStatusValue)
+  }
+
+  func testGetLatestValidatedLedgerSequence() {
+    // GIVEN a `ReliableSubmissionClient` decorating a FakeXpringClient WHEN the latest ledger sequence is retrieved THEN the result is returned unaltered.
+    XCTAssertEqual(try? reliableSubmissionClient.getLatestValidatedLedgerSequence(), defaultLastestValidatedLedgerValue)
+  }
+
+  func testGetRawTransactionStatus() {
+    // GIVEN a `ReliableSubmissionClient` decorating a FakeXpringClient WHEN a raw transaction status is retrieved THEN the result is returned unaltered.
+    XCTAssertEqual(try? reliableSubmissionClient.getRawTransactionStatus(for: .testTransactionHash), defaultRawTransactionStatusValue)
+  }
+
+  func testSendWithExpiredLedgerSequenceAndUnvalidatedTransaction() throws {
+    // GIVEN A ledger sequence number that will increment in 60s.
+    let lastLedgerSequence: UInt32 = 20
+    fakeXpringClient.rawTransactionStatusValue = Io_Xpring_TransactionStatus.with {
+      $0.validated = false
+      $0.lastLedgerSequence = lastLedgerSequence
+      $0.transactionStatusCode = "tesSuccess"
+    }
+    runAfterOneSecond({ self.fakeXpringClient.latestValidatedLedgerValue = lastLedgerSequence + 1 })
+
+    // WHEN a reliable send is submitted
+    let expectation = XCTestExpectation(description: "Send returned")
+    do {
+      _ = try reliableSubmissionClient.send(BigUInt(10), to: .testAddress, from: .testWallet)
+      expectation.fulfill()
+    } catch {
+      XCTFail("Caught unexpected error while calling `send`: \(error)")
+    }
+
+    // THEN the function returns
+    self.wait(for: [ expectation ], timeout: 10)
+  }
+
+  func testSendWithUnexpiredLedgerSequenceAndValidatedTransaction() throws {
+    // GIVEN A ledger sequence number that will increment in 60s.
+    let lastLedgerSequence: UInt32 = 20
+    fakeXpringClient.rawTransactionStatusValue = Io_Xpring_TransactionStatus.with {
+      $0.validated = false
+      $0.lastLedgerSequence = lastLedgerSequence
+      $0.transactionStatusCode = "tesSuccess"
+    }
+    runAfterOneSecond({ self.fakeXpringClient.rawTransactionStatusValue.validated = true })
+
+    // WHEN a reliable send is submitted
+    let expectation = XCTestExpectation(description: "Send returned")
+    do {
+      _ = try reliableSubmissionClient.send(BigUInt(10), to: .testAddress, from: .testWallet)
+      expectation.fulfill()
+    } catch {
+      XCTFail("Caught unexpected error while calling `send`: \(error)")
+    }
+
+    // THEN the function returns
+    self.wait(for: [ expectation ], timeout: 10)
+  }
+
+  func testSendWithNoLastLedgerSequence() throws {
+    // GIVEN a `ReliableSubmissionXpringClient` decorating a `FakeXpringClient` which will return a transaction that did not have a last ledger sequence attached.
+    fakeXpringClient.rawTransactionStatusValue = Io_Xpring_TransactionStatus.with {
+      $0.validated = false
+      $0.transactionStatusCode = "tesSuccess"
+    }
+
+    // WHEN a reliable send is submitted THEN an error is thrown.
+    XCTAssertThrowsError(try reliableSubmissionClient.send(BigUInt(10), to: .testAddress, from: .testWallet))
+  }
+
+  // MARK: - Helpers
+
+  func runAfterOneSecond(_ task: @escaping () -> Void) {
+    DispatchQueue.global(qos: .userInteractive).asyncAfter(deadline: (.now() + 1)) { task() }
+  }
+}

--- a/XpringKit.xcodeproj/project.pbxproj
+++ b/XpringKit.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		205EA5A430DFABF45C2A221F /* SwiftGRPC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 58A74192BD297BC4E78F9B95 /* SwiftGRPC.framework */; };
 		260AFFFF6F99434B982D02A3 /* xrp_amount.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD81AC2984EC4A639432DD2A /* xrp_amount.pb.swift */; };
 		28430C7E1BD753FC9BEE2746 /* XRPJavaScriptLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265F737D13784A1A6341E3E4 /* XRPJavaScriptLoader.swift */; };
+		2978A5F9E3F8AF7049C6459E /* ReliableSubmissionXpringClientTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFA016E351D30D824FF119A /* ReliableSubmissionXpringClientTest.swift */; };
 		2AC840E88FB8A6ACF88F4351 /* ReliableSubmissionXpringClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 175AAD5AEF79820FF7FCCE80 /* ReliableSubmissionXpringClient.swift */; };
 		2D9D7BFF942A6DB46A9E602D /* XpringKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2A961F46C813F5BA0254F222 /* XpringKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2DFB7C1BCA54ED07FCEE083A /* WalletGenerationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADD0BDE0881A1C6DDE6D939A /* WalletGenerationResult.swift */; };
@@ -49,6 +50,7 @@
 		418FA404281A1EB7FC192194 /* JavaScriptUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E0C0E9FDF3E68693B2C4B9 /* JavaScriptUtils.swift */; };
 		4358ECC24A624D8C4C3F9CF4 /* RandomBytesUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6652A59C1C60CE0A44DB808D /* RandomBytesUtil.swift */; };
 		44BB5E8E869A5F2DBE53D878 /* get_account_info_request.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB4A173BD30FAD23D9B68B0E /* get_account_info_request.pb.swift */; };
+		48113CAF3E46ED0ED426D1D0 /* TransactionHash+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F383DDDD9638F0BDC8C016 /* TransactionHash+Test.swift */; };
 		52FEEA10075B52FD7F425E46 /* XRPJavaScriptLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265F737D13784A1A6341E3E4 /* XRPJavaScriptLoader.swift */; };
 		559ED2AB9EF5FD27838AA624 /* FakeNetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ACE19B61522015207CC5FB4 /* FakeNetworkClient.swift */; };
 		567AA63408E8F1A026494AAF /* XpringKitTestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8113A7B1A4F26A434C63CDF8 /* XpringKitTestError.swift */; };
@@ -75,6 +77,7 @@
 		7B9ADCFF14AF87E6751F8E46 /* Address+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = B26D12954276D34124999E61 /* Address+Test.swift */; };
 		7DA4A6E51E3AFAFBED32306F /* currency.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BEFEBC1AAB0132A6C7440B /* currency.pb.swift */; };
 		7F29A55A5EE4CB4A41C73E2B /* TransactionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBB02CC192CD7AE7E3218E98 /* TransactionStatus.swift */; };
+		7FC50C37A67CE21E363753CD /* ReliableSubmissionXpringClientTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFA016E351D30D824FF119A /* ReliableSubmissionXpringClientTest.swift */; };
 		81696621C0B84D6070610A93 /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E488ABD93CCADA4769887E2 /* SwiftProtobuf.framework */; };
 		81C5E3886C4126C4CF497F8B /* ByteArray+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DD77F8CDC039E5870305B91 /* ByteArray+Hex.swift */; };
 		8665AF97EFA52EE4A094CAC6 /* get_latest_validated_ledger_sequence_request.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFD34F71A81FED319AFC579E /* get_latest_validated_ledger_sequence_request.pb.swift */; };
@@ -112,6 +115,7 @@
 		D568D029304542FFFE4BF029 /* currency.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BEFEBC1AAB0132A6C7440B /* currency.pb.swift */; };
 		D6B744875D9A6AA6BB314AD5 /* xrp_ledger.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1384056BF33A696E0FB72E50 /* xrp_ledger.pb.swift */; };
 		DB26AC6D896AF31860B1CCE8 /* WalletGenerationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADD0BDE0881A1C6DDE6D939A /* WalletGenerationResult.swift */; };
+		DBF344E3EBAFC39311529A2E /* FakeXpringClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC3C1F97079E9102F5DEC2A /* FakeXpringClient.swift */; };
 		DD3AAD707E92A1DEBD1C7A36 /* get_fee_request.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 944EFFFB8A6091E800186EFB /* get_fee_request.pb.swift */; };
 		DE97916A0CF7F8BB7853108D /* submit_signed_transaction_request.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E59B88FC8EA85680CB46773 /* submit_signed_transaction_request.pb.swift */; };
 		DF2A9BC219387399F91B7D56 /* XpringKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1EA17318980B00CB10EAF3D4 /* XpringKit.framework */; };
@@ -127,7 +131,9 @@
 		F047D499C409455893734DDE /* JavaScriptSigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DF0085EF32E1A8F9FC3FFF /* JavaScriptSigner.swift */; };
 		F1325A49C497A4C39141E751 /* WalletTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05F8765E9BE754C41FCEB39 /* WalletTest.swift */; };
 		F2FC131ECE631D33B7010580 /* JSValue+JavaScriptWalletGenerationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B4FBDD3CCA9E931913B59C /* JSValue+JavaScriptWalletGenerationResult.swift */; };
+		F3CF8F0714D07FEA894C87B3 /* TransactionHash+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F383DDDD9638F0BDC8C016 /* TransactionHash+Test.swift */; };
 		F41382C64F2ACB1F096350F8 /* transaction.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63746318EFEF269F11698161 /* transaction.pb.swift */; };
+		FB5975520257746149AAEC06 /* FakeXpringClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC3C1F97079E9102F5DEC2A /* FakeXpringClient.swift */; };
 		FB60706C284D4869588ACD12 /* XRPLedgerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 367711CBA6DD24C5C890B35F /* XRPLedgerError.swift */; };
 		FF78A09CEC303B89851054E5 /* JSValue+JavaScriptWallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A8DF813EA75BD18BE4F7E7 /* JSValue+JavaScriptWallet.swift */; };
 		FFDD4E05736F1A79B6DB680B /* NetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4505055EADFAE26992AF3B /* NetworkClient.swift */; };
@@ -204,6 +210,7 @@
 		6652A59C1C60CE0A44DB808D /* RandomBytesUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomBytesUtil.swift; sourceTree = "<group>"; };
 		6B4505055EADFAE26992AF3B /* NetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
 		6D4D56F206D17777FA6E54E1 /* SwiftProtobuf.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SwiftProtobuf.framework; sourceTree = "<group>"; };
+		76F383DDDD9638F0BDC8C016 /* TransactionHash+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TransactionHash+Test.swift"; sourceTree = "<group>"; };
 		7ACE19B61522015207CC5FB4 /* FakeNetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeNetworkClient.swift; sourceTree = "<group>"; };
 		7B9235E33F4B53ED0FD35D50 /* SignerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignerTests.swift; sourceTree = "<group>"; };
 		8113A7B1A4F26A434C63CDF8 /* XpringKitTestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XpringKitTestError.swift; sourceTree = "<group>"; };
@@ -218,6 +225,7 @@
 		A56D70978C361F6E73333A5E /* ledger_sequence.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ledger_sequence.pb.swift; sourceTree = "<group>"; };
 		ACC165482A69C013773E743E /* RippledServiceClient+NetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RippledServiceClient+NetworkClient.swift"; sourceTree = "<group>"; };
 		ADD0BDE0881A1C6DDE6D939A /* WalletGenerationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletGenerationResult.swift; sourceTree = "<group>"; };
+		AEFA016E351D30D824FF119A /* ReliableSubmissionXpringClientTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReliableSubmissionXpringClientTest.swift; sourceTree = "<group>"; };
 		B26D12954276D34124999E61 /* Address+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Address+Test.swift"; sourceTree = "<group>"; };
 		B42C1A6AD7B7AC4F5483751E /* IntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationTests.swift; sourceTree = "<group>"; };
 		B547FCA69236588FE4BACDE9 /* transaction_status.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = transaction_status.pb.swift; sourceTree = "<group>"; };
@@ -235,6 +243,7 @@
 		D05F8765E9BE754C41FCEB39 /* WalletTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletTest.swift; sourceTree = "<group>"; };
 		D2BEFEBC1AAB0132A6C7440B /* currency.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = currency.pb.swift; sourceTree = "<group>"; };
 		D9713E57588F07A7974AB830 /* XpringKitTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = XpringKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DBC3C1F97079E9102F5DEC2A /* FakeXpringClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeXpringClient.swift; sourceTree = "<group>"; };
 		DCF6B999FCE0C29CC7A59D45 /* XpringKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = XpringKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA714A0B484B0B0CB6D39B77 /* BigInt.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = BigInt.framework; sourceTree = "<group>"; };
 		EB4A173BD30FAD23D9B68B0E /* get_account_info_request.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = get_account_info_request.pb.swift; sourceTree = "<group>"; };
@@ -309,6 +318,7 @@
 			isa = PBXGroup;
 			children = (
 				B26D12954276D34124999E61 /* Address+Test.swift */,
+				76F383DDDD9638F0BDC8C016 /* TransactionHash+Test.swift */,
 				8113A7B1A4F26A434C63CDF8 /* XpringKitTestError.swift */,
 			);
 			path = Helpers;
@@ -381,6 +391,7 @@
 			isa = PBXGroup;
 			children = (
 				7ACE19B61522015207CC5FB4 /* FakeNetworkClient.swift */,
+				DBC3C1F97079E9102F5DEC2A /* FakeXpringClient.swift */,
 			);
 			path = Fakes;
 			sourceTree = "<group>";
@@ -436,6 +447,7 @@
 			children = (
 				FB8141A7936A12BB62F71D89 /* DefaultXpringClientTest.swift */,
 				B42C1A6AD7B7AC4F5483751E /* IntegrationTests.swift */,
+				AEFA016E351D30D824FF119A /* ReliableSubmissionXpringClientTest.swift */,
 				7B9235E33F4B53ED0FD35D50 /* SignerTests.swift */,
 				C1D0F50AF49F103E1E0B3D50 /* UtilsTest.swift */,
 				D05F8765E9BE754C41FCEB39 /* WalletTest.swift */,
@@ -675,8 +687,11 @@
 				1053167CEB5E37D821825F29 /* Address+Test.swift in Sources */,
 				A6F54469EDE978937427DC52 /* DefaultXpringClientTest.swift in Sources */,
 				559ED2AB9EF5FD27838AA624 /* FakeNetworkClient.swift in Sources */,
+				FB5975520257746149AAEC06 /* FakeXpringClient.swift in Sources */,
 				6B85D18D3F38F8968EF41032 /* IntegrationTests.swift in Sources */,
+				2978A5F9E3F8AF7049C6459E /* ReliableSubmissionXpringClientTest.swift in Sources */,
 				5B2931FD0FA9B76E09BA277F /* SignerTests.swift in Sources */,
+				F3CF8F0714D07FEA894C87B3 /* TransactionHash+Test.swift in Sources */,
 				7B4DACB74AC645F871515879 /* UtilsTest.swift in Sources */,
 				712A85D43E83845BBC6C1FA6 /* WalletTest.swift in Sources */,
 				79415A03BDDA31881344FB83 /* XpringKitTestError.swift in Sources */,
@@ -690,8 +705,11 @@
 				7B9ADCFF14AF87E6751F8E46 /* Address+Test.swift in Sources */,
 				E390C1796DDC19E93B9F58E4 /* DefaultXpringClientTest.swift in Sources */,
 				B525EDC4B7BBAB3CF674891F /* FakeNetworkClient.swift in Sources */,
+				DBF344E3EBAFC39311529A2E /* FakeXpringClient.swift in Sources */,
 				7B54EC43CDEB457E0A065ED2 /* IntegrationTests.swift in Sources */,
+				7FC50C37A67CE21E363753CD /* ReliableSubmissionXpringClientTest.swift in Sources */,
 				0F49532FCD38B077540E4627 /* SignerTests.swift in Sources */,
+				48113CAF3E46ED0ED426D1D0 /* TransactionHash+Test.swift in Sources */,
 				E4DE5E80EB10CE7EC39BC7CA /* UtilsTest.swift in Sources */,
 				F1325A49C497A4C39141E751 /* WalletTest.swift in Sources */,
 				567AA63408E8F1A026494AAF /* XpringKitTestError.swift in Sources */,

--- a/XpringKit.xcodeproj/project.pbxproj
+++ b/XpringKit.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		14C52DF737EB8AAF92188760 /* transaction.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63746318EFEF269F11698161 /* transaction.pb.swift */; };
 		1762612E093C2CE2658EF529 /* XpringKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1EA17318980B00CB10EAF3D4 /* XpringKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		177C7EB5457C7873594BB71C /* xrp_ledger.grpc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CA071C002701FF9AEF2C2B0 /* xrp_ledger.grpc.swift */; };
+		179ECB919EF25B89D2B36F34 /* ReliableSubmissionXpringClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 175AAD5AEF79820FF7FCCE80 /* ReliableSubmissionXpringClient.swift */; };
 		1B837832A7F24AE4BFCBA83D /* get_account_info_request.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB4A173BD30FAD23D9B68B0E /* get_account_info_request.pb.swift */; };
 		1DE5DD931D662C2AE9A11278 /* account_info.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88FF35FE995B5EA7A4F5C0FF /* account_info.pb.swift */; };
 		1E6AFE0AF006DE4A93E6C447 /* RippledServiceClient+NetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACC165482A69C013773E743E /* RippledServiceClient+NetworkClient.swift */; };
@@ -30,6 +31,7 @@
 		205EA5A430DFABF45C2A221F /* SwiftGRPC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 58A74192BD297BC4E78F9B95 /* SwiftGRPC.framework */; };
 		260AFFFF6F99434B982D02A3 /* xrp_amount.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD81AC2984EC4A639432DD2A /* xrp_amount.pb.swift */; };
 		28430C7E1BD753FC9BEE2746 /* XRPJavaScriptLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265F737D13784A1A6341E3E4 /* XRPJavaScriptLoader.swift */; };
+		2AC840E88FB8A6ACF88F4351 /* ReliableSubmissionXpringClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 175AAD5AEF79820FF7FCCE80 /* ReliableSubmissionXpringClient.swift */; };
 		2D9D7BFF942A6DB46A9E602D /* XpringKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2A961F46C813F5BA0254F222 /* XpringKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2DFB7C1BCA54ED07FCEE083A /* WalletGenerationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADD0BDE0881A1C6DDE6D939A /* WalletGenerationResult.swift */; };
 		2E74A8B58BC16DD3EBD77AE3 /* Wallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFA89B2B4CE85050623E1F1A /* Wallet.swift */; };
@@ -184,6 +186,7 @@
 		0DD77F8CDC039E5870305B91 /* ByteArray+Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ByteArray+Hex.swift"; sourceTree = "<group>"; };
 		0E59B88FC8EA85680CB46773 /* submit_signed_transaction_request.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = submit_signed_transaction_request.pb.swift; sourceTree = "<group>"; };
 		1384056BF33A696E0FB72E50 /* xrp_ledger.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = xrp_ledger.pb.swift; sourceTree = "<group>"; };
+		175AAD5AEF79820FF7FCCE80 /* ReliableSubmissionXpringClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReliableSubmissionXpringClient.swift; sourceTree = "<group>"; };
 		1DD3840185E5F1F74EC56D27 /* DefaultXpringClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultXpringClient.swift; sourceTree = "<group>"; };
 		1DDCBA2B158736EC1BF44901 /* fee.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = fee.pb.swift; sourceTree = "<group>"; };
 		1E488ABD93CCADA4769887E2 /* SwiftProtobuf.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SwiftProtobuf.framework; sourceTree = "<group>"; };
@@ -331,6 +334,7 @@
 				FCD54D1CD3F440E73218FF8B /* Hex.swift */,
 				6B4505055EADFAE26992AF3B /* NetworkClient.swift */,
 				6652A59C1C60CE0A44DB808D /* RandomBytesUtil.swift */,
+				175AAD5AEF79820FF7FCCE80 /* ReliableSubmissionXpringClient.swift */,
 				ACC165482A69C013773E743E /* RippledServiceClient+NetworkClient.swift */,
 				C987E39201D5B0AA9E73428E /* Signer.swift */,
 				FB2C2BF0895DEDD1C9AB5D2D /* TransactionHash.swift */,
@@ -631,6 +635,7 @@
 				C1119E71DBAA8D0A9CC9E275 /* JavaScriptWalletGenerationResult.swift in Sources */,
 				1194FDFC16C03EBA2B6D6C5D /* NetworkClient.swift in Sources */,
 				6F01B174655CF9505B5BA44B /* RandomBytesUtil.swift in Sources */,
+				2AC840E88FB8A6ACF88F4351 /* ReliableSubmissionXpringClient.swift in Sources */,
 				1E6AFE0AF006DE4A93E6C447 /* RippledServiceClient+NetworkClient.swift in Sources */,
 				3290ACBFC35352A9E8A83C27 /* Signer.swift in Sources */,
 				4060097AAC967721CFA653BB /* TransactionHash.swift in Sources */,
@@ -712,6 +717,7 @@
 				5DD0CF7ED7032C6DD176EC72 /* JavaScriptWalletGenerationResult.swift in Sources */,
 				FFDD4E05736F1A79B6DB680B /* NetworkClient.swift in Sources */,
 				4358ECC24A624D8C4C3F9CF4 /* RandomBytesUtil.swift in Sources */,
+				179ECB919EF25B89D2B36F34 /* ReliableSubmissionXpringClient.swift in Sources */,
 				138FBD4E100E3D90656346EB /* RippledServiceClient+NetworkClient.swift in Sources */,
 				6933342C51E08FAFA80E5244 /* Signer.swift in Sources */,
 				79FD2BD66600BDE782DE7C0A /* TransactionHash.swift in Sources */,

--- a/XpringKit.xcodeproj/project.pbxproj
+++ b/XpringKit.xcodeproj/project.pbxproj
@@ -247,7 +247,7 @@
 		DCF6B999FCE0C29CC7A59D45 /* XpringKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = XpringKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA714A0B484B0B0CB6D39B77 /* BigInt.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = BigInt.framework; sourceTree = "<group>"; };
 		EB4A173BD30FAD23D9B68B0E /* get_account_info_request.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = get_account_info_request.pb.swift; sourceTree = "<group>"; };
-		EE83B9D92E9AB2959A1C76A5 /* bundled.js */ = {isa = PBXFileReference; path = bundled.js; sourceTree = "<group>"; };
+		EE83B9D92E9AB2959A1C76A5 /* bundled.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = bundled.js; sourceTree = "<group>"; };
 		F39CB9BAD86A33B832774635 /* XpringClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XpringClient.swift; sourceTree = "<group>"; };
 		F5E0C0E9FDF3E68693B2C4B9 /* JavaScriptUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JavaScriptUtils.swift; sourceTree = "<group>"; };
 		F8C5EEE32B50B1DA49AD37B9 /* JavaScriptWallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JavaScriptWallet.swift; sourceTree = "<group>"; };
@@ -555,6 +555,7 @@
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				Base,
 				en,
 			);
 			mainGroup = BBAD321263700FD683CDB723;
@@ -940,8 +941,8 @@
 				);
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "io.xpring.XpringKitTests-macOS";
 				PRODUCT_NAME = XpringKitTests;
@@ -960,8 +961,8 @@
 				);
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "io.xpring.XpringKitTests-macOS";
 				PRODUCT_NAME = XpringKitTests;

--- a/XpringKit.xcodeproj/xcshareddata/xcschemes/XpringKit_iOS.xcscheme
+++ b/XpringKit.xcodeproj/xcshareddata/xcschemes/XpringKit_iOS.xcscheme
@@ -27,6 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference

--- a/XpringKit.xcodeproj/xcshareddata/xcschemes/XpringKit_macOS.xcscheme
+++ b/XpringKit.xcodeproj/xcshareddata/xcschemes/XpringKit_macOS.xcscheme
@@ -27,6 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference

--- a/XpringKit/DefaultXpringClient.swift
+++ b/XpringKit/DefaultXpringClient.swift
@@ -6,7 +6,7 @@ public class DefaultXpringClient {
   private let ledgerSequenceMargin: UInt32 = 10
 
   /// A network client that will make and receive requests.
-	public let networkClient: NetworkClient
+	private let networkClient: NetworkClient
 
   /// Initialize a new XRPClient.
   ///

--- a/XpringKit/DefaultXpringClient.swift
+++ b/XpringKit/DefaultXpringClient.swift
@@ -1,12 +1,12 @@
 import BigInt
 
 /// An interface into the Xpring Platform.
-public class DefaultXpringClient: XpringClientDecorator {
+public class DefaultXpringClient {
   /// A margin to pad the current ledger sequence with when submitting transactions.
   private let ledgerSequenceMargin: UInt32 = 10
 
   /// A network client that will make and receive requests.
-	private let networkClient: NetworkClient
+	public let networkClient: NetworkClient
 
   /// Initialize a new XRPClient.
   ///
@@ -23,6 +23,30 @@ public class DefaultXpringClient: XpringClientDecorator {
 		self.networkClient = networkClient
 	}
 
+  /// Retrieve an `AccountInfo` for an address on the XRP Ledger.
+  ///
+  /// - Parameter address: The address to retrieve information about.
+  /// - Throws: An error if there was a problem communicating with the XRP Ledger.
+  /// - Returns: An `AccountInfo` containing data about the given address.
+  private func getAccountInfo(for address: Address) throws -> Io_Xpring_AccountInfo {
+    let getAccountInfoRequest = Io_Xpring_GetAccountInfoRequest.with {
+      $0.address = address
+    }
+
+    return try networkClient.getAccountInfo(getAccountInfoRequest)
+  }
+
+  /// Retrieve the current fee to submit a transaction to the XRP Ledger.
+  ///
+  /// - Throws: An error if there was a problem communicating with the XRP Ledger.
+  /// - Returns: A `Fee` for submitting a transaction to the ledger.
+  private func getFee() throws -> Io_Xpring_Fee {
+    let getFeeRequest = Io_Xpring_GetFeeRequest()
+    return try networkClient.getFee(getFeeRequest)
+  }
+}
+
+extension DefaultXpringClient: XpringClientDecorator {
 	/// Get the balance for the given address.
 	///
 	/// - Parameter address: The X-Address to retrieve the balance for.
@@ -36,6 +60,22 @@ public class DefaultXpringClient: XpringClientDecorator {
 		let accountInfo = try getAccountInfo(for: address)
     return BigUInt(stringLiteral: accountInfo.balance.drops)
 	}
+
+  /// Retrieve the transaction status for a given transaction hash.
+  ///
+  /// - Parameter transactionHash: The hash of the transaction.
+  /// - Throws: An error if there was a problem communicating with the XRP Ledger.
+  /// - Returns: The status of the given transaction.
+  public func getTransactionStatus(for transactionHash: TransactionHash) throws -> TransactionStatus {
+    let transactionStatusRequest = Io_Xpring_GetTransactionStatusRequest.with { $0.transactionHash = transactionHash }
+    let transactionStatus = try networkClient.getTransactionStatus(transactionStatusRequest)
+
+    // Return pending if the transaction is not validated.
+    guard transactionStatus.validated else {
+      return .pending
+    }
+    return transactionStatus.transactionStatusCode.starts(with: "tes") ? .succeeded : .failed
+  }
 
 	/// Send XRP to a recipient on the XRP Ledger.
 	///
@@ -85,49 +125,11 @@ public class DefaultXpringClient: XpringClientDecorator {
     return hash
   }
 
-	/// Retrieve the current fee to submit a transaction to the XRP Ledger.
-	///
-	/// - Throws: An error if there was a problem communicating with the XRP Ledger.
-	/// - Returns: A `Fee` for submitting a transaction to the ledger.
-	private func getFee() throws -> Io_Xpring_Fee {
-		let getFeeRequest = Io_Xpring_GetFeeRequest()
-		return try networkClient.getFee(getFeeRequest)
-	}
-
-	/// Retrieve an `AccountInfo` for an address on the XRP Ledger.
-	///
-	/// - Parameter address: The address to retrieve information about.
-	/// - Throws: An error if there was a problem communicating with the XRP Ledger.
-	/// - Returns: An `AccountInfo` containing data about the given address.
-	private func getAccountInfo(for address: Address) throws -> Io_Xpring_AccountInfo {
-		let getAccountInfoRequest = Io_Xpring_GetAccountInfoRequest.with {
-			$0.address = address
-		}
-
-		return try networkClient.getAccountInfo(getAccountInfoRequest)
-  }
-
-  /// Retrieve the transaction status for a given transaction hash.
-  ///
-  /// - Parameter transactionHash: The hash of the transaction.
-  /// - Throws: An error if there was a problem communicating with the XRP Ledger.
-  /// - Returns: The status of the given transaction.
-  public func getTransactionStatus(for transactionHash: TransactionHash) throws -> TransactionStatus {
-    let transactionStatusRequest = Io_Xpring_GetTransactionStatusRequest.with { $0.transactionHash = transactionHash }
-    let transactionStatus = try networkClient.getTransactionStatus(transactionStatusRequest)
-
-    // Return pending if the transaction is not validated.
-    guard transactionStatus.validated else {
-      return .pending
-    }
-    return transactionStatus.transactionStatusCode.starts(with: "tes") ? .succeeded : .failed
-  }
-
   /// Retrieve the latest validated ledger sequence on the XRP Ledger.
   ///
   /// - Throws: An error if there was a problem communicating with the XRP Ledger.
   /// - Returns: The index of the latest validated ledger.
-  private func getLatestValidatedLedgerSequence() throws -> UInt32 {
+  public func getLatestValidatedLedgerSequence() throws -> UInt32 {
     let getLatestValidatedLedgerSequenceRequest = Io_Xpring_GetLatestValidatedLedgerSequenceRequest()
     let ledgerSequence = try networkClient.getLatestValidatedLedgerSequence(getLatestValidatedLedgerSequenceRequest)
     return UInt32(ledgerSequence.index)

--- a/XpringKit/DefaultXpringClient.swift
+++ b/XpringKit/DefaultXpringClient.swift
@@ -67,8 +67,7 @@ extension DefaultXpringClient: XpringClientDecorator {
   /// - Throws: An error if there was a problem communicating with the XRP Ledger.
   /// - Returns: The status of the given transaction.
   public func getTransactionStatus(for transactionHash: TransactionHash) throws -> TransactionStatus {
-    let transactionStatusRequest = Io_Xpring_GetTransactionStatusRequest.with { $0.transactionHash = transactionHash }
-    let transactionStatus = try networkClient.getTransactionStatus(transactionStatusRequest)
+    let transactionStatus = try getRawTransactionStatus(for: transactionHash)
 
     // Return pending if the transaction is not validated.
     guard transactionStatus.validated else {
@@ -133,5 +132,15 @@ extension DefaultXpringClient: XpringClientDecorator {
     let getLatestValidatedLedgerSequenceRequest = Io_Xpring_GetLatestValidatedLedgerSequenceRequest()
     let ledgerSequence = try networkClient.getLatestValidatedLedgerSequence(getLatestValidatedLedgerSequenceRequest)
     return UInt32(ledgerSequence.index)
+  }
+
+  /// Retrieve the raw transaction status for the given transaction hash.
+  ///
+  /// - Parameter transactionHash: The hash of the transaction.
+  /// - Throws: An error if there was a problem communicating with the XRP Ledger.
+  /// - Returns: The status of the given transaction.
+  public func getRawTransactionStatus(for transactionHash: TransactionHash) throws -> Io_Xpring_TransactionStatus {
+    let transactionStatusRequest = Io_Xpring_GetTransactionStatusRequest.with { $0.transactionHash = transactionHash }
+    return try networkClient.getTransactionStatus(transactionStatusRequest)
   }
 }

--- a/XpringKit/ReliableSubmissionXpringClient.swift
+++ b/XpringKit/ReliableSubmissionXpringClient.swift
@@ -11,12 +11,6 @@ public class ReliableSubmissionXpringClient {
 }
 
 extension ReliableSubmissionXpringClient: XpringClientDecorator {
-
-  // TODO(network client doesn't need to be public
-  public var networkClient: NetworkClient {
-    return decoratedClient.networkClient
-  }
-
   public func getBalance(for address: Address) throws -> BigUInt {
     return try decoratedClient.getBalance(for: address)
   }

--- a/XpringKit/ReliableSubmissionXpringClient.swift
+++ b/XpringKit/ReliableSubmissionXpringClient.swift
@@ -1,0 +1,58 @@
+import BigInt
+import Foundation
+
+/// A XpringClient which blocks on `send` calls until the transaction has reached a deterministic state.
+public class ReliableSubmissionXpringClient {
+  private let decoratedClient: XpringClientDecorator
+
+  public init(decoratedClient: XpringClientDecorator) {
+    self.decoratedClient = decoratedClient
+  }
+}
+
+extension ReliableSubmissionXpringClient: XpringClientDecorator {
+  public var networkClient: NetworkClient {
+    return decoratedClient.networkClient
+  }
+
+  public func getBalance(for address: Address) throws -> BigUInt {
+    return try decoratedClient.getBalance(for: address)
+  }
+
+  public func getTransactionStatus(for transactionHash: TransactionHash) throws -> TransactionStatus {
+    return try decoratedClient.getTransactionStatus(for: transactionHash)
+  }
+
+  public func getLatestValidatedLedgerSequence() throws -> UInt32 {
+    return try decoratedClient.getLatestValidatedLedgerSequence()
+  }
+
+  public func send(_ amount: BigUInt, to destinationAddress: Address, from sourceWallet: Wallet) throws -> TransactionHash {
+    let ledgerCloseTime: TimeInterval = 4
+
+    // Submit a transaction hash and wait for a ledger to close.
+    let transactionHash = try decoratedClient.send(amount, to: destinationAddress, from: sourceWallet)
+    Thread.sleep(forTimeInterval: ledgerCloseTime)
+
+    // Get transaction status.
+    let transactionStatusRequest = Io_Xpring_GetTransactionStatusRequest.with { $0.transactionHash = transactionHash }
+    var transactionStatus = try networkClient.getTransactionStatus(transactionStatusRequest)
+    let lastLedgerSequence = transactionStatus.lastLedgerSequence
+    if (lastLedgerSequence == 0) {
+      throw XRPLedgerError.unknown("The transaction did not have a lastLedgerSequence field so transaction status cannot be reliably determined.")
+    }
+
+    // Retrieve the latest ledger index.
+    var latestLedgerSequence = try getLatestValidatedLedgerSequence()
+
+    // Poll until the transaction is validated, or until the lastLedgerSequence has been passed.
+    while (lastLedgerSequence <= latestLedgerSequence && !transactionStatus.validated) {
+      Thread.sleep(forTimeInterval: ledgerCloseTime)
+
+      latestLedgerSequence = try getLatestValidatedLedgerSequence()
+      transactionStatus = try networkClient.getTransactionStatus(transactionStatusRequest)
+    }
+
+    return transactionHash
+  }
+}

--- a/XpringKit/XpringClient.swift
+++ b/XpringKit/XpringClient.swift
@@ -1,14 +1,15 @@
 import BigInt
 
 /// An interface into the Xpring Platform.
-public class XpringClient: XpringClientDecorator {
+public class XpringClient {
   private let decoratedClient: XpringClientDecorator
 
   /// Initialize a new XpringClient.
   ///
   /// - Parameter grpcURL: A remote URL for a rippled gRPC service.
   public init(grpcURL: String) {
-    decoratedClient = DefaultXpringClient(grpcURL: grpcURL)
+    let defaultClient = DefaultXpringClient(grpcURL: grpcURL)
+    decoratedClient = ReliableSubmissionXpringClient(decoratedClient: defaultClient)
   }
 
   /// Get the balance for the given address.

--- a/XpringKit/XpringClientDecorator.swift
+++ b/XpringKit/XpringClientDecorator.swift
@@ -2,9 +2,6 @@ import BigInt
 
 /// A decorator for a XpringClient.
 public protocol XpringClientDecorator {
-  /// The network client which can make requests a remote node.
-  var networkClient: NetworkClient { get }
-
   /// Get the balance for the given address.
   ///
   /// - Parameter address: The X-Address to retrieve the balance for.

--- a/XpringKit/XpringClientDecorator.swift
+++ b/XpringKit/XpringClientDecorator.swift
@@ -2,6 +2,9 @@ import BigInt
 
 /// A decorator for a XpringClient.
 public protocol XpringClientDecorator {
+  /// The network client which can make requests a remote node.
+  var networkClient: NetworkClient { get }
+
   /// Get the balance for the given address.
   ///
   /// - Parameter address: The X-Address to retrieve the balance for.
@@ -25,4 +28,10 @@ public protocol XpringClientDecorator {
   /// - Throws: An error if there was a problem communicating with the XRP Ledger or the inputs were invalid.
   /// - Returns: A transaction hash for the submitted transaction.
   func send(_ amount: BigUInt, to destinationAddress: Address, from sourceWallet: Wallet) throws -> TransactionHash
+
+  /// Retrieve the latest validated ledger sequence on the XRP Ledger.
+  ///
+  /// - Throws: An error if there was a problem communicating with the XRP Ledger.
+  /// - Returns: The index of the latest validated ledger.
+  func getLatestValidatedLedgerSequence() throws -> UInt32
 }

--- a/XpringKit/XpringClientDecorator.swift
+++ b/XpringKit/XpringClientDecorator.swift
@@ -34,4 +34,11 @@ public protocol XpringClientDecorator {
   /// - Throws: An error if there was a problem communicating with the XRP Ledger.
   /// - Returns: The index of the latest validated ledger.
   func getLatestValidatedLedgerSequence() throws -> UInt32
+
+  /// Retrieve the raw transaction status for the given transaction hash.
+  ///
+  /// - Parameter transactionHash: The hash of the transaction.
+  /// - Throws: An error if there was a problem communicating with the XRP Ledger.
+  /// - Returns: The status of the given transaction.
+  func getRawTransactionStatus(for transactionHash: TransactionHash) throws -> Io_Xpring_TransactionStatus
 }

--- a/project.yml
+++ b/project.yml
@@ -12,7 +12,7 @@ targets:
     resources: [XpringKit/Resources]
     scheme:
       testTargets:
-        - XpringKitTests_$platform
+        - XpringKitTests_${platform}
       gatherCoverageData: true
     postCompileScripts:
       - script: swiftlint autocorrect --config .swiftlint.yml
@@ -26,4 +26,4 @@ targets:
     platform: [iOS, macOS]
     sources: [Tests]
     dependencies:
-      - target: XpringKit_$platform
+      - target: XpringKit_${platform}


### PR DESCRIPTION
Make calls to submit transactions block until the transaction status can be reliably determined. 

Note that as a product decision, this functionality is non-optional and thread blocking. 

New Classes:
- `ReliableSubmissionXpringClient`: Polls and blocks when submitting a transaction. Conforms to `XpringClientDecorator` and wraps `DefaultXpringClient`. 
- `ReliableSubmissionXpringClientTest`: Unit tests
- `FakeXpringClient`: A fake `XpringClientDecorator` used to unit test `ReliableXpringClient`

Future work may include:
- Making this functionality optional
- Using non-blocking calls
- Returning a transactionStatus along with a transaction hash

This is part of a trio of PRs across Xpring SDK:
- Xpring-JS / Javascript: https://github.com/xpring-eng/Xpring-JS/pull/88
- Xpring4J / Java: https://github.com/xpring-eng/xpring4j/pull/49