### PR TITLE
Pass through `test` parameter when Decoding X-Addresses 

### DIFF
--- a/Tests/UtilsTest.swift
+++ b/Tests/UtilsTest.swift
@@ -145,8 +145,8 @@ class UtilsTest: XCTestCase {
 
   // MARK: - decode
 
-  func testDecodeXAddressWithAddressAndTag() {
-    // GIVEN an x-address that encodes an address and a tag.
+  func testDecodeMainNetXAddressWithAddressAndTag() {
+    // GIVEN an X-Address on MainNet that encodes an address and a tag.
     let address = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT"
 
     // WHEN it is decoded to an classic address
@@ -158,6 +158,23 @@ class UtilsTest: XCTestCase {
     // THEN the decoded address and tag as are expected.
     XCTAssertEqual(classicAddressTuple.classicAddress, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1")
     XCTAssertEqual(classicAddressTuple.tag, 12_345)
+    XCTAssertFalse(classicAddressTuple.isTest)
+  }
+
+  func testDecodeTestNetXAddressWithAddressAndTag() {
+    // GIVEN an X-Address on Testnet that encodes an address and a tag.
+    let address = "TVsBZmcewpEHgajPi1jApLeYnHPJw82v9JNYf7dkGmWphmh"
+
+    // WHEN it is decoded to an classic address
+    guard let classicAddressTuple = Utils.decode(xAddress: address) else {
+      XCTFail("Failed to decode a valid X-Address")
+      return
+    }
+
+    // THEN the decoded address and tag as are expected.
+    XCTAssertEqual(classicAddressTuple.classicAddress, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1")
+    XCTAssertEqual(classicAddressTuple.tag, 12_345)
+    XCTAssertTrue(classicAddressTuple.isTest)
   }
 
   func testDecodeXAddressWithAddressOnly() {

--- a/XpringKit/JavaScript/JavaScriptUtils.swift
+++ b/XpringKit/JavaScript/JavaScriptUtils.swift
@@ -12,6 +12,7 @@ internal class JavaScriptUtils {
     public static let isValidClassicAddress = "isValidClassicAddress"
     public static let isValidXAddress = "isValidXAddress"
     public static let tag = "tag"
+    public static let test = "test"
     public static let transactionBlobToTransactionHash = "transactionBlobToTransactionHash"
     public static let utils = "Utils"
   }
@@ -95,18 +96,19 @@ internal class JavaScriptUtils {
   /// - SeeAlso: https://xrpaddress.info/
   ///
   /// - Parameter xAddress: The X-Address to decode.
-  /// - Returns: a tuple containing the decoded address and tag.
-  public func decode(xAddress: Address) -> (classicAddress: String, tag: UInt32?)? {
+  /// - Returns: a tuple containing the decoded address,  tag and bool indicating if the address was on a test network.
+  public func decode(xAddress: Address) -> (classicAddress: String, tag: UInt32?, isTest: Bool)? {
     let result = decodeXAddressFunction.call(withArguments: [ xAddress ])!
     guard !result.isUndefined else {
       return nil
     }
 
     let classicAddress = XRPJavaScriptLoader.load(ResourceNames.address, from: result).toString()!
+    let isTest = XRPJavaScriptLoader.load(ResourceNames.test, from: result).toBool()
     if let tag = XRPJavaScriptLoader.failableLoad(ResourceNames.tag, from: result) {
-      return (classicAddress, tag.toUInt32())
+      return (classicAddress, tag.toUInt32(), isTest)
     }
-    return (classicAddress, nil)
+    return (classicAddress, nil, isTest)
   }
 
   /// Convert the given transaction blob to a transaction hash.

--- a/XpringKit/ReliableSubmissionXpringClient.swift
+++ b/XpringKit/ReliableSubmissionXpringClient.swift
@@ -37,7 +37,7 @@ extension ReliableSubmissionXpringClient: XpringClientDecorator {
     // Get transaction status.
     var transactionStatus = try getRawTransactionStatus(for: transactionHash)
     let lastLedgerSequence = transactionStatus.lastLedgerSequence
-    if (lastLedgerSequence == 0) {
+    if lastLedgerSequence == 0 {
       throw XRPLedgerError.unknown("The transaction did not have a lastLedgerSequence field so transaction status cannot be reliably determined.")
     }
 
@@ -45,7 +45,7 @@ extension ReliableSubmissionXpringClient: XpringClientDecorator {
     var latestLedgerSequence = try getLatestValidatedLedgerSequence()
 
     // Poll until the transaction is validated, or until the lastLedgerSequence has been passed.
-    while (latestLedgerSequence <= lastLedgerSequence && !transactionStatus.validated) {
+    while latestLedgerSequence <= lastLedgerSequence && !transactionStatus.validated {
       Thread.sleep(forTimeInterval: ledgerCloseTime)
 
       latestLedgerSequence = try getLatestValidatedLedgerSequence()

--- a/XpringKit/Utils.swift
+++ b/XpringKit/Utils.swift
@@ -50,8 +50,8 @@ public enum Utils {
   /// - SeeAlso: https://xrpaddress.info/
   ///
   /// - Parameter xAddress: The xAddress to decode.
-  /// - Returns: a tuple containing the decoded address and tag.
-  public static func decode(xAddress: Address) -> (classicAddress: String, tag: UInt32?)? {
+  /// - Returns: a tuple containing the decoded address,  tag and bool indicating if the address was on a test network.
+  public static func decode(xAddress: Address) -> (classicAddress: String, tag: UInt32?, isTest: Bool)? {
     return javaScriptUtils.decode(xAddress: xAddress)
   }
 


### PR DESCRIPTION
Currently, the test parameter is dropped when decoding X-Addresses. Pass this data through to clients rather than dropping it.

Tested:
- Unit tests

Note that the unit test case is derived from manually checking values on http://xrpaddress.info.

--- 
Underlying core implementation done in: https://github.com/xpring-eng/xpring-common-js/pull/103