### PR TITLE
[Build Fix] Specify Ruby Version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,6 @@ jobs:
             brew install xcodegen swiftlint swift-protobuf grpc-swift
             brew upgrade
             npm i -g grpc-tools
-            xcode-select --install
             sudo gem install slather cocoapods
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           name: "Install Tooling"
           command: |
             brew update
-            brew install xcodegen swiftlint swift-protobuf grpc-swift
+            brew install xcodegen swiftlint swift-protobuf grpc-swift ruby
             brew upgrade
             npm i -g grpc-tools
             sudo gem install slather cocoapods

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,17 +14,18 @@ jobs:
       - run:
           name: "System Information"
           command: xcodebuild -version
-
+      - run:
+          name: Set Ruby Version
+          command:  echo "ruby-2.6.4" > ~/.ruby-version
+  
       - run:
           name: "Install Tooling"
           command: |
             brew update
-            brew install xcodegen swiftlint swift-protobuf grpc-swift ruby
+            brew install xcodegen swiftlint swift-protobuf grpc-swift
             brew upgrade
             npm i -g grpc-tools
             xcode-select --install
-            sudo xcodebuild -license
-            sudo gem update --system
             sudo gem install slather cocoapods
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,8 @@ jobs:
             brew install xcodegen swiftlint swift-protobuf grpc-swift ruby
             brew upgrade
             npm i -g grpc-tools
+            xcode-select --install
+            sudo xcodebuild -license
             sudo gem update --system
             sudo gem install slather cocoapods
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
             brew install xcodegen swiftlint swift-protobuf grpc-swift ruby
             brew upgrade
             npm i -g grpc-tools
+            sudo gem update --system
             sudo gem install slather cocoapods
 
       - run:


### PR DESCRIPTION
CircleCI requires an explicit statement of Ruby version on newer versions of their MacOS containers.

I'm not sure how we ever got away without doing this, but according to their documentation we need to add this build step:  https://circleci.com/docs/2.0/testing-ios/#images-using-macos-1015-catalina--xcode-112-and-later

Note that we could also just commit another `.ruby_version` file to our repo. I prefer to try to keep meaningless config files out of the repo when possible, but happy to reverse course if reviewers feel strongly. 