### PR TITLE
Add `test` parameter when Encoding X-Addresses

### DIFF
--- a/Tests/UtilsTest.swift
+++ b/Tests/UtilsTest.swift
@@ -17,7 +17,7 @@ class UtilsTest: XCTestCase {
     XCTAssertFalse(Utils.isValid(address: "1EAG1MwmzkG6gRZcYqcRMfC17eMt8TDTit"))
 	}
 
-	func testIsvValidAddressInvalidChecksumClassicAddress() {
+	func testIsValidAddressInvalidChecksumClassicAddress() {
     XCTAssertFalse(Utils.isValid(address: "rU6K7V3Po4sBBBBBaU29sesqs2qTQJWDw1"))
 	}
 
@@ -109,16 +109,28 @@ class UtilsTest: XCTestCase {
 
   // MARK: - encode
 
-  func testEncodeXAddressWithAddressAndTag() {
+  func testEncodeMainNetXAddressWithAddressAndTag() {
     // GIVEN a valid classic address and a tag.
     let address =  "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"
     let tag: UInt32 = 12_345
 
-    // WHEN they are encoded to an x-address.
+    // WHEN they are encoded to an X-Address on MainNet.
     let xAddress = Utils.encode(classicAddress: address, tag: tag)
 
     // THEN the result is as expected.
     XCTAssertEqual(xAddress, "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT")
+  }
+
+  func testEncodeTestNetXAddressWithAddressAndTag() {
+    // GIVEN a valid classic address and a tag.
+    let address =  "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"
+    let tag: UInt32 = 12_345
+
+    // WHEN they are encoded to an X-Address on MainNet.
+    let xAddress = Utils.encode(classicAddress: address, tag: tag, isTest: true)
+
+    // THEN the result is as expected.
+    XCTAssertEqual(xAddress, "TVsBZmcewpEHgajPi1jApLeYnHPJw82v9JNYf7dkGmWphmh")
   }
 
   func testEncodeXAddressWithAddressOnly() {

--- a/Tests/UtilsTest.swift
+++ b/Tests/UtilsTest.swift
@@ -145,8 +145,8 @@ class UtilsTest: XCTestCase {
 
   // MARK: - decode
 
-  func testDecodeXAddressWithAddressAndTag() {
-    // GIVEN an x-address that encodes an address and a tag.
+  func testDecodeMainNetXAddressWithAddressAndTag() {
+    // GIVEN an X-Address on MainNet that encodes an address and a tag.
     let address = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT"
 
     // WHEN it is decoded to an classic address
@@ -158,6 +158,23 @@ class UtilsTest: XCTestCase {
     // THEN the decoded address and tag as are expected.
     XCTAssertEqual(classicAddressTuple.classicAddress, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1")
     XCTAssertEqual(classicAddressTuple.tag, 12_345)
+    XCTAssertFalse(classicAddressTuple.isTest)
+  }
+
+  func testDecodeTestNetXAddressWithAddressAndTag() {
+    // GIVEN an X-Address on Testnet that encodes an address and a tag.
+    let address = "TVsBZmcewpEHgajPi1jApLeYnHPJw82v9JNYf7dkGmWphmh"
+
+    // WHEN it is decoded to an classic address
+    guard let classicAddressTuple = Utils.decode(xAddress: address) else {
+      XCTFail("Failed to decode a valid X-Address")
+      return
+    }
+
+    // THEN the decoded address and tag as are expected.
+    XCTAssertEqual(classicAddressTuple.classicAddress, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1")
+    XCTAssertEqual(classicAddressTuple.tag, 12_345)
+    XCTAssertTrue(classicAddressTuple.isTest)
   }
 
   func testDecodeXAddressWithAddressOnly() {

--- a/XpringKit/JavaScript/JavaScriptUtils.swift
+++ b/XpringKit/JavaScript/JavaScriptUtils.swift
@@ -12,6 +12,7 @@ internal class JavaScriptUtils {
     public static let isValidClassicAddress = "isValidClassicAddress"
     public static let isValidXAddress = "isValidXAddress"
     public static let tag = "tag"
+    public static let test = "test"
     public static let transactionBlobToTransactionHash = "transactionBlobToTransactionHash"
     public static let utils = "Utils"
   }
@@ -95,18 +96,19 @@ internal class JavaScriptUtils {
   /// - SeeAlso: https://xrpaddress.info/
   ///
   /// - Parameter xAddress: The X-Address to decode.
-  /// - Returns: a tuple containing the decoded address and tag.
-  public func decode(xAddress: Address) -> (classicAddress: String, tag: UInt32?)? {
+  /// - Returns: a tuple containing the decoded address,  tag and bool indicating if the address was on a test network.
+  public func decode(xAddress: Address) -> (classicAddress: String, tag: UInt32?, isTest: Bool)? {
     let result = decodeXAddressFunction.call(withArguments: [ xAddress ])!
     guard !result.isUndefined else {
       return nil
     }
 
     let classicAddress = XRPJavaScriptLoader.load(ResourceNames.address, from: result).toString()!
+    let isTest = XRPJavaScriptLoader.load(ResourceNames.test, from: result).toBool()
     if let tag = XRPJavaScriptLoader.failableLoad(ResourceNames.tag, from: result) {
-      return (classicAddress, tag.toUInt32())
+      return (classicAddress, tag.toUInt32(), isTest)
     }
-    return (classicAddress, nil)
+    return (classicAddress, nil, isTest)
   }
 
   /// Convert the given transaction blob to a transaction hash.

--- a/XpringKit/JavaScript/JavaScriptUtils.swift
+++ b/XpringKit/JavaScript/JavaScriptUtils.swift
@@ -80,12 +80,14 @@ internal class JavaScriptUtils {
   /// - Parameters:
   ///   -  classicAddress: A classic address to encode.
   ///   - tag: An optional tag to encode. Defaults to nil.
+  ///   - isTest Whether the address is for use on a test network, defaults to `false`.
   /// - Returns: A new X-address if inputs were valid, otherwise undefined.
-  public func encode(classicAddress: Address, tag: UInt32? = nil) -> Address? {
+  public func encode(classicAddress: Address, tag: UInt32? = nil, isTest: Bool = false) -> Address? {
     var arguments: [Any] = [ classicAddress ]
     if tag != nil {
       arguments.append(tag as Any)
     }
+    arguments.append(isTest)
 
     let result = encodeXAddressFunction.call(withArguments: arguments)!
     return result.isUndefined ? nil : result.toString()

--- a/XpringKit/ReliableSubmissionXpringClient.swift
+++ b/XpringKit/ReliableSubmissionXpringClient.swift
@@ -37,7 +37,7 @@ extension ReliableSubmissionXpringClient: XpringClientDecorator {
     // Get transaction status.
     var transactionStatus = try getRawTransactionStatus(for: transactionHash)
     let lastLedgerSequence = transactionStatus.lastLedgerSequence
-    if (lastLedgerSequence == 0) {
+    if lastLedgerSequence == 0 {
       throw XRPLedgerError.unknown("The transaction did not have a lastLedgerSequence field so transaction status cannot be reliably determined.")
     }
 
@@ -45,7 +45,7 @@ extension ReliableSubmissionXpringClient: XpringClientDecorator {
     var latestLedgerSequence = try getLatestValidatedLedgerSequence()
 
     // Poll until the transaction is validated, or until the lastLedgerSequence has been passed.
-    while (latestLedgerSequence <= lastLedgerSequence && !transactionStatus.validated) {
+    while latestLedgerSequence <= lastLedgerSequence && !transactionStatus.validated {
       Thread.sleep(forTimeInterval: ledgerCloseTime)
 
       latestLedgerSequence = try getLatestValidatedLedgerSequence()

--- a/XpringKit/Utils.swift
+++ b/XpringKit/Utils.swift
@@ -50,8 +50,8 @@ public enum Utils {
   /// - SeeAlso: https://xrpaddress.info/
   ///
   /// - Parameter xAddress: The xAddress to decode.
-  /// - Returns: a tuple containing the decoded address and tag.
-  public static func decode(xAddress: Address) -> (classicAddress: String, tag: UInt32?)? {
+  /// - Returns: a tuple containing the decoded address,  tag and bool indicating if the address was on a test network.
+  public static func decode(xAddress: Address) -> (classicAddress: String, tag: UInt32?, isTest: Bool)? {
     return javaScriptUtils.decode(xAddress: xAddress)
   }
 

--- a/XpringKit/Utils.swift
+++ b/XpringKit/Utils.swift
@@ -40,9 +40,10 @@ public enum Utils {
   /// - Parameters:
   ///   -  classicAddress: A classic address to encode.
   ///   - tag: An optional tag to encode. Defaults to nil.
+  ///   - isTest Whether the address is for use on a test network, defaults to `false`.
   /// - Returns: A new x-address if inputs were valid, otherwise undefined.
-  public static func encode(classicAddress: Address, tag: UInt32? = nil) -> Address? {
-    return javaScriptUtils.encode(classicAddress: classicAddress, tag: tag)
+  public static func encode(classicAddress: Address, tag: UInt32? = nil, isTest: Bool = false) -> Address? {
+    return javaScriptUtils.encode(classicAddress: classicAddress, tag: tag, isTest: isTest)
   }
 
   /// Decode a classic address from a given x-address.


### PR DESCRIPTION
X-Addresses support a special format for TestNet. Xpring-Common-JS currently ignores this parameter and defaults everything to mainnet. 

Add support for this parameter. Make the parameter optional and default to mainnnet. This is because I think:
- Most folks will just want mainnet addresses by default
- The behavior of existing code won't change, so we can release this as a point fix

Tested:
- Unit tests

Note that the unit test case is derived from manually checking values on http://xrpaddress.info.

---
Underlying core implementation done in: https://github.com/xpring-eng/xpring-common-js/pull/104