### PR TITLE
Pass through `test` parameter when creating Wallets

### DIFF
--- a/Tests/UtilsTest.swift
+++ b/Tests/UtilsTest.swift
@@ -17,7 +17,7 @@ class UtilsTest: XCTestCase {
     XCTAssertFalse(Utils.isValid(address: "1EAG1MwmzkG6gRZcYqcRMfC17eMt8TDTit"))
 	}
 
-	func testIsvValidAddressInvalidChecksumClassicAddress() {
+	func testIsValidAddressInvalidChecksumClassicAddress() {
     XCTAssertFalse(Utils.isValid(address: "rU6K7V3Po4sBBBBBaU29sesqs2qTQJWDw1"))
 	}
 
@@ -109,16 +109,28 @@ class UtilsTest: XCTestCase {
 
   // MARK: - encode
 
-  func testEncodeXAddressWithAddressAndTag() {
+  func testEncodeMainNetXAddressWithAddressAndTag() {
     // GIVEN a valid classic address and a tag.
     let address =  "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"
     let tag: UInt32 = 12_345
 
-    // WHEN they are encoded to an x-address.
+    // WHEN they are encoded to an X-Address on MainNet.
     let xAddress = Utils.encode(classicAddress: address, tag: tag)
 
     // THEN the result is as expected.
     XCTAssertEqual(xAddress, "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT")
+  }
+
+  func testEncodeTestNetXAddressWithAddressAndTag() {
+    // GIVEN a valid classic address and a tag.
+    let address =  "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"
+    let tag: UInt32 = 12_345
+
+    // WHEN they are encoded to an X-Address on MainNet.
+    let xAddress = Utils.encode(classicAddress: address, tag: tag, isTest: true)
+
+    // THEN the result is as expected.
+    XCTAssertEqual(xAddress, "TVsBZmcewpEHgajPi1jApLeYnHPJw82v9JNYf7dkGmWphmh")
   }
 
   func testEncodeXAddressWithAddressOnly() {

--- a/Tests/UtilsTest.swift
+++ b/Tests/UtilsTest.swift
@@ -145,8 +145,8 @@ class UtilsTest: XCTestCase {
 
   // MARK: - decode
 
-  func testDecodeXAddressWithAddressAndTag() {
-    // GIVEN an x-address that encodes an address and a tag.
+  func testDecodeMainNetXAddressWithAddressAndTag() {
+    // GIVEN an X-Address on MainNet that encodes an address and a tag.
     let address = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT"
 
     // WHEN it is decoded to an classic address
@@ -158,6 +158,23 @@ class UtilsTest: XCTestCase {
     // THEN the decoded address and tag as are expected.
     XCTAssertEqual(classicAddressTuple.classicAddress, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1")
     XCTAssertEqual(classicAddressTuple.tag, 12_345)
+    XCTAssertFalse(classicAddressTuple.isTest)
+  }
+
+  func testDecodeTestNetXAddressWithAddressAndTag() {
+    // GIVEN an X-Address on Testnet that encodes an address and a tag.
+    let address = "TVsBZmcewpEHgajPi1jApLeYnHPJw82v9JNYf7dkGmWphmh"
+
+    // WHEN it is decoded to an classic address
+    guard let classicAddressTuple = Utils.decode(xAddress: address) else {
+      XCTFail("Failed to decode a valid X-Address")
+      return
+    }
+
+    // THEN the decoded address and tag as are expected.
+    XCTAssertEqual(classicAddressTuple.classicAddress, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1")
+    XCTAssertEqual(classicAddressTuple.tag, 12_345)
+    XCTAssertTrue(classicAddressTuple.isTest)
   }
 
   func testDecodeXAddressWithAddressOnly() {

--- a/Tests/WalletTest.swift
+++ b/Tests/WalletTest.swift
@@ -2,7 +2,7 @@ import XCTest
 import XpringKit
 
 class WalletTest: XCTestCase {
-	func testGenerateWalletFromSeed() {
+	func testGenerateMainNetWalletFromSeed() {
 		guard let wallet = Wallet(seed: "snYP7oArxKepd3GPDcrjMsJYiJeJB") else {
 			XCTFail("Could not generate wallet")
 			return
@@ -11,6 +11,16 @@ class WalletTest: XCTestCase {
 		XCTAssertNotNil(wallet)
 		XCTAssertEqual(wallet.address, "XVnJMYQFqA8EAijpKh5EdjEY5JqyxykMKKSbrUX8uchF6U8")
 	}
+
+  func testGenerateTestNetWalletFromSeed() {
+    guard let wallet = Wallet(seed: "snYP7oArxKepd3GPDcrjMsJYiJeJB", isTest: true) else {
+      XCTFail("Could not generate wallet")
+      return
+    }
+
+    XCTAssertNotNil(wallet)
+    XCTAssertEqual(wallet.address, "T7zFmeZo6uLHP4Vd21TpXjrTBk487ZQPGVQsJ1mKWGCD5rq")
+  }
 
 	func testGenerateWalletFromInvalidSeed() {
 		let wallet = Wallet(seed: "xrp")
@@ -34,7 +44,7 @@ class WalletTest: XCTestCase {
 		XCTAssertEqual(wallet.address, "XVMFQQBMhdouRqhPMuawgBMN1AVFTofPAdRsXG5RkPtUPNQ")
 	}
 
-	func testGenerateWalletFromMnemonicDerivationPath0() {
+	func testGenerateMainNetWalletFromMnemonicDerivationPath0() {
 		let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
 		let derivationPath = "m/44'/144'/0'/0/0"
 		guard let wallet = Wallet(mnemonic: mnemonic, derivationPath: derivationPath) else {
@@ -46,6 +56,19 @@ class WalletTest: XCTestCase {
 		XCTAssertEqual(wallet.privateKey, "0090802A50AA84EFB6CDB225F17C27616EA94048C179142FECF03F4712A07EA7A4")
 		XCTAssertEqual(wallet.address, "XVMFQQBMhdouRqhPMuawgBMN1AVFTofPAdRsXG5RkPtUPNQ")
 	}
+
+  func testGenerateTestNetWalletFromMnemonicDerivationPath0() {
+    let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+    let derivationPath = "m/44'/144'/0'/0/0"
+    guard let wallet = Wallet(mnemonic: mnemonic, derivationPath: derivationPath, isTest: true) else {
+      XCTFail("Could not generate wallet")
+      return
+    }
+
+    XCTAssertEqual(wallet.publicKey, "031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE")
+    XCTAssertEqual(wallet.privateKey, "0090802A50AA84EFB6CDB225F17C27616EA94048C179142FECF03F4712A07EA7A4")
+    XCTAssertEqual(wallet.address, "TVHLFWLKvbMv1LFzd6FA2Bf9MPpcy4mRto4VFAAxLuNpvdW")
+  }
 
 	func testGenerateWalletFromMnemonicDerivationPath1() {
 		let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"

--- a/XpringKit/JavaScript/JavaScriptUtils.swift
+++ b/XpringKit/JavaScript/JavaScriptUtils.swift
@@ -12,6 +12,7 @@ internal class JavaScriptUtils {
     public static let isValidClassicAddress = "isValidClassicAddress"
     public static let isValidXAddress = "isValidXAddress"
     public static let tag = "tag"
+    public static let test = "test"
     public static let transactionBlobToTransactionHash = "transactionBlobToTransactionHash"
     public static let utils = "Utils"
   }
@@ -95,18 +96,19 @@ internal class JavaScriptUtils {
   /// - SeeAlso: https://xrpaddress.info/
   ///
   /// - Parameter xAddress: The X-Address to decode.
-  /// - Returns: a tuple containing the decoded address and tag.
-  public func decode(xAddress: Address) -> (classicAddress: String, tag: UInt32?)? {
+  /// - Returns: a tuple containing the decoded address,  tag and bool indicating if the address was on a test network.
+  public func decode(xAddress: Address) -> (classicAddress: String, tag: UInt32?, isTest: Bool)? {
     let result = decodeXAddressFunction.call(withArguments: [ xAddress ])!
     guard !result.isUndefined else {
       return nil
     }
 
     let classicAddress = XRPJavaScriptLoader.load(ResourceNames.address, from: result).toString()!
+    let isTest = XRPJavaScriptLoader.load(ResourceNames.test, from: result).toBool()
     if let tag = XRPJavaScriptLoader.failableLoad(ResourceNames.tag, from: result) {
-      return (classicAddress, tag.toUInt32())
+      return (classicAddress, tag.toUInt32(), isTest)
     }
-    return (classicAddress, nil)
+    return (classicAddress, nil, isTest)
   }
 
   /// Convert the given transaction blob to a transaction hash.

--- a/XpringKit/JavaScript/JavaScriptUtils.swift
+++ b/XpringKit/JavaScript/JavaScriptUtils.swift
@@ -80,12 +80,14 @@ internal class JavaScriptUtils {
   /// - Parameters:
   ///   -  classicAddress: A classic address to encode.
   ///   - tag: An optional tag to encode. Defaults to nil.
+  ///   - isTest Whether the address is for use on a test network, defaults to `false`.
   /// - Returns: A new X-address if inputs were valid, otherwise undefined.
-  public func encode(classicAddress: Address, tag: UInt32? = nil) -> Address? {
+  public func encode(classicAddress: Address, tag: UInt32? = nil, isTest: Bool = false) -> Address? {
     var arguments: [Any] = [ classicAddress ]
     if tag != nil {
       arguments.append(tag as Any)
     }
+    arguments.append(isTest)
 
     let result = encodeXAddressFunction.call(withArguments: arguments)!
     return result.isUndefined ? nil : result.toString()

--- a/XpringKit/JavaScript/JavaScriptWalletFactory.swift
+++ b/XpringKit/JavaScript/JavaScriptWalletFactory.swift
@@ -40,10 +40,11 @@ internal class JavaScriptWalletFactory {
 	///
 	/// - Note: This call uses Swift's Math.Random functionality to ensure randomly generated numbers are cryptographically secure.
 	///
+  /// - Parameter isTest: Whether the address is for use on a test network.
 	/// - Returns: Artifacts of the generation process in a WalletGenerationResult.
-	public func generateRandomWallet() -> JavaScriptWalletGenerationResult {
+	public func generateRandomWallet(isTest: Bool = false) -> JavaScriptWalletGenerationResult {
 		let randomBytesHex = RandomBytesUtil.randomBytes(numBytes: 16).toHex()
-		let result = generateRandomWalletFunction.call(withArguments: [ randomBytesHex ])!
+		let result = generateRandomWalletFunction.call(withArguments: [ randomBytesHex, isTest ])!
 		return result.toWalletGenerationResult()!
 	}
 
@@ -52,12 +53,16 @@ internal class JavaScriptWalletFactory {
 	/// - Parameters:
 	///		- mnemonic: A space delimited list of seed words for the `Wallet`.
 	///		- derivationPath: A derivation path for the `Wallet`. If nil, the default derivation path will be used.
+  ///   - isTest: Whether the address is for use on a test network.
 	/// - Returns: A new wallet if inputs were valid, otherwise nil.
-	public func wallet(mnemonic: String, derivationPath: String? = nil) -> JavaScriptWallet? {
-		var arguments = [mnemonic]
+	public func wallet(mnemonic: String, derivationPath: String? = nil, isTest: Bool = false) -> JavaScriptWallet? {
+    var arguments: [Any] = [mnemonic]
 		if let derivationPath = derivationPath {
 			arguments.append(derivationPath)
-		}
+    } else {
+      arguments.append(JSValue(undefinedIn: XRPJavaScriptLoader.XRPJavaScriptContext) as Any)
+    }
+    arguments.append(isTest)
 
 		let result = generateWalletFromMnemonicFunction.call(withArguments: arguments)!
 		return result.toWallet()
@@ -65,10 +70,12 @@ internal class JavaScriptWalletFactory {
 
 	/// Initialize a new `Wallet` with a base58check encoded seed.
 	///
-	/// - Parameter seed: The seed used to generate the `Wallet`.
+	/// - Parameters:
+  ///   - seed: The seed used to generate the `Wallet`.
+  ///   - isTest: Whether the address is for use on a test network.
 	/// - Returns: A new wallet if inputs were valid, otherwise nil.
-	public func wallet(seed: String) -> JavaScriptWallet? {
-		let result = generateWalletFromSeedFunction.call(withArguments: [ seed ])!
+	public func wallet(seed: String, isTest: Bool = false) -> JavaScriptWallet? {
+		let result = generateWalletFromSeedFunction.call(withArguments: [ seed, isTest ])!
 		return result.toWallet()
 	}
 }

--- a/XpringKit/ReliableSubmissionXpringClient.swift
+++ b/XpringKit/ReliableSubmissionXpringClient.swift
@@ -37,7 +37,7 @@ extension ReliableSubmissionXpringClient: XpringClientDecorator {
     // Get transaction status.
     var transactionStatus = try getRawTransactionStatus(for: transactionHash)
     let lastLedgerSequence = transactionStatus.lastLedgerSequence
-    if (lastLedgerSequence == 0) {
+    if lastLedgerSequence == 0 {
       throw XRPLedgerError.unknown("The transaction did not have a lastLedgerSequence field so transaction status cannot be reliably determined.")
     }
 
@@ -45,7 +45,7 @@ extension ReliableSubmissionXpringClient: XpringClientDecorator {
     var latestLedgerSequence = try getLatestValidatedLedgerSequence()
 
     // Poll until the transaction is validated, or until the lastLedgerSequence has been passed.
-    while (latestLedgerSequence <= lastLedgerSequence && !transactionStatus.validated) {
+    while latestLedgerSequence <= lastLedgerSequence && !transactionStatus.validated {
       Thread.sleep(forTimeInterval: ledgerCloseTime)
 
       latestLedgerSequence = try getLatestValidatedLedgerSequence()

--- a/XpringKit/Utils.swift
+++ b/XpringKit/Utils.swift
@@ -50,8 +50,8 @@ public enum Utils {
   /// - SeeAlso: https://xrpaddress.info/
   ///
   /// - Parameter xAddress: The xAddress to decode.
-  /// - Returns: a tuple containing the decoded address and tag.
-  public static func decode(xAddress: Address) -> (classicAddress: String, tag: UInt32?)? {
+  /// - Returns: a tuple containing the decoded address,  tag and bool indicating if the address was on a test network.
+  public static func decode(xAddress: Address) -> (classicAddress: String, tag: UInt32?, isTest: Bool)? {
     return javaScriptUtils.decode(xAddress: xAddress)
   }
 

--- a/XpringKit/Utils.swift
+++ b/XpringKit/Utils.swift
@@ -40,9 +40,10 @@ public enum Utils {
   /// - Parameters:
   ///   -  classicAddress: A classic address to encode.
   ///   - tag: An optional tag to encode. Defaults to nil.
+  ///   - isTest Whether the address is for use on a test network, defaults to `false`.
   /// - Returns: A new x-address if inputs were valid, otherwise undefined.
-  public static func encode(classicAddress: Address, tag: UInt32? = nil) -> Address? {
-    return javaScriptUtils.encode(classicAddress: classicAddress, tag: tag)
+  public static func encode(classicAddress: Address, tag: UInt32? = nil, isTest: Bool = false) -> Address? {
+    return javaScriptUtils.encode(classicAddress: classicAddress, tag: tag, isTest: isTest)
   }
 
   /// Decode a classic address from a given x-address.

--- a/XpringKit/Wallet.swift
+++ b/XpringKit/Wallet.swift
@@ -24,9 +24,10 @@ public class Wallet {
 	///
 	/// - Note: This call uses Swift's Math.Random functionality to ensure randomly generated numbers are cryptographically secure.
 	///
+  /// - Parameter isTest: Whether the address is for use on a test network.
 	/// - Returns: Artifacts of the generation process in a WalletGenerationResult.
-	public static func generateRandomWallet() -> WalletGenerationResult {
-		let javaScriptWalletGenerationResult = Wallet.javaScriptWalletFactory.generateRandomWallet()
+  public static func generateRandomWallet(isTest: Bool = false) -> WalletGenerationResult {
+		let javaScriptWalletGenerationResult = Wallet.javaScriptWalletFactory.generateRandomWallet(isTest: isTest)
 		return WalletGenerationResult(javaScriptWalletGenerationResult: javaScriptWalletGenerationResult)
 	}
 
@@ -35,11 +36,13 @@ public class Wallet {
 	/// - Parameters:
 	///		- mnemonic: A space delimited list of seed words for the `Wallet`.
 	///		- derivationPath: A derivation path for the `Wallet`. If nil, the default derivation path will be used.
+  ///   - isTest: Whether the address is for use on a test network.
 	/// - Returns: A new wallet if inputs were valid, otherwise nil.
-	public convenience init?(mnemonic: String, derivationPath: String? = nil) {
+	public convenience init?(mnemonic: String, derivationPath: String? = nil, isTest: Bool = false) {
 		guard let javaScriptWallet = Wallet.javaScriptWalletFactory.wallet(
 			mnemonic: mnemonic,
-			derivationPath: derivationPath
+			derivationPath: derivationPath,
+      isTest: isTest
 		) else {
 			return nil
 		}
@@ -48,10 +51,12 @@ public class Wallet {
 
 	/// Initialize a new `Wallet` with a base58check encoded seed.
 	///
-	/// - Parameter seed: The seed used to generate the `Wallet`.
+	/// - Parameters:
+  ///   - seed: The seed used to generate the `Wallet`.
+  ///   - isTest: Whether the address is for use on a test network.
 	/// - Returns: A new wallet if inputs were valid, otherwise nil.
-	public convenience init?(seed: String) {
-		guard let javaScriptWallet = Wallet.javaScriptWalletFactory.wallet(seed: seed) else {
+	public convenience init?(seed: String, isTest: Bool = false) {
+    guard let javaScriptWallet = Wallet.javaScriptWalletFactory.wallet(seed: seed, isTest: isTest) else {
 			return nil
 		}
 		self.init(javaScriptWallet: javaScriptWallet)


### PR DESCRIPTION
X-Addresses support a special format for TestNet. Xpring-Common-JS currently ignores this parameter and defaults everything to MainNet.

Add support for this parameter in all initializers and factory methods of the `Wallet` class. Pass through this parameter to the address derivation code. 

Make the parameter optional and default to MainNet. This is because I think:
- Most folks will just want mainnet addresses by default
- The behavior of existing code won't change, so we can release this as a point fix

Tested:
- Unit tests

Note that the unit test case is derived from manually checking values on http://xrpaddress.info.

----

Note this was originally implemented in: https://github.com/xpring-eng/xpring-common-js/pull/105