### PR TITLE
Implement PayID Get

### DIFF
--- a/Tests/DefaultIlpClientTest.swift
+++ b/Tests/DefaultIlpClientTest.swift
@@ -7,35 +7,34 @@ final class DefaultIlpClientTest: XCTestCase {
     // MARK: - Balance
     func testGetBalanceWithSuccess() {
         // GIVEN an IlpClient which will successfully return a balance from a mocked network call.
-        
+
         // WHEN the balance is requested
-        
+
         // THEN the balance is correct
     }
-    
+
     func testGetBalanceWithFailure() {
         // GIVEN an IlpClient with a network client which will always throw an error.
-        
+
         // WHEN the balance is requested
-        
+
         // THEN an error is thrown
     }
-    
 
     // MARK: - Payment
     func testSendPaymentWithSuccess() {
         // GIVEN an IlpClient which will successfully return a payment response from a mocked network call.
-        
+
         // WHEN a payment is sent
-        
+
         // THEN the payment response is correct
     }
-    
+
     func testSendPaymentWithFailure() {
         // GIVEN an IlpClient with a network client which will always throw an error.
-        
+
         // WHEN a payment is sent
-        
+
         // THEN an error is thrown
     }
 }

--- a/Tests/Fakes/FakeURLSession.swift
+++ b/Tests/Fakes/FakeURLSession.swift
@@ -1,32 +1,44 @@
-//import Foundation
-//
-///// Fakes a URLSession for testing.
-//class FakeURLSession: URLSession {
-//  typealias CompletionHandler = (Data?, URLResponse?, Error?) -> Void
-//
-//  // Data returned by the next request
-//  var data: Data?
-//
-//  // The HTTPURLResponse returned by the next request
-//  var urlResponse: HTTPURLResponse?
-//
-//  // Error returned by the next request.
-//  var error: Error?
-//
-//  public init(string: String?, urlResponse: HTTPURLResponse?, error: Error?) {
-//    self.data = string?.data(using: .utf8)
-//    self.urlResponse = urlResponse
-//    self.error = error
-//
-//    super.init()
-//  }
-//
-//  override func dataTask(
-//    with url: URL,
-//    completionHandler: @escaping CompletionHandler
-//  ) -> URLSessionDataTask {
-//    return FakeURLSessionDataTask {
-//      completionHandler(self.data, self.urlResponse, self.error)
-//    }
-//  }
-//}
+import Foundation
+
+/// A fake URLSession that will return data tasks which will call completion handlers with the given parameters.
+public class FakeURLSession: URLSession {
+  /// Fields that will be returned in the next URLSessionDataTask.
+  public var urlResponse: URLResponse?
+  public var data: Data?
+  public var error: Error?
+
+  /// Initialize a new FakeURLSession.
+  ///
+  /// - Parameters:
+  ///   - string: A utf-8 encoded string that will be encoded as data in the next request.
+  ///   - urlResponse: The url response to serve in the next request.
+  ///   - error: The error to serve in the next request.
+  public convenience init(string: String, urlResponse: HTTPURLResponse?, error: Error?) {
+    let data = string.data(using: .utf8)
+    self.init(data: data, urlResponse: urlResponse, error: error)
+  }
+
+  /// Initialize a new FakeURLSession.
+  ///
+  /// - Parameters:
+  ///   - data: The data to serve in the next request.
+  ///   - urlResponse: The url response to serve in the next request.
+  ///   - error: The error to serve in the next request.
+  public init(data: Data?, urlResponse: HTTPURLResponse?, error: Error?) {
+    self.data = data
+    self.urlResponse = urlResponse
+    self.error = error
+  }
+
+  public override func dataTask(
+    with request: URLRequest,
+    completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void
+  ) -> URLSessionDataTask {
+    return FakeURLSessionDataTask(
+      urlResponse: urlResponse,
+      data: data,
+      error: error,
+      completionHandler: completionHandler
+    )
+  }
+}

--- a/Tests/Fakes/FakeURLSessionDataTask.swift
+++ b/Tests/Fakes/FakeURLSessionDataTask.swift
@@ -1,14 +1,25 @@
-//import Foundation
-//
-///// Fakes a URLSessionDataTask for testing.
-//class FakeURLSessionDataTask: URLSessionDataTask {
-//    private let closure: () -> Void
-//
-//    init(closure: @escaping () -> Void) {
-//        self.closure = closure
-//    }
-//
-//    override func resume() {
-//        closure()
-//    }
-//}
+import Foundation
+
+/// A fake data task that will immediately call completion.
+public class FakeURLSessionDataTask: URLSessionDataTask {
+  private let urlResponse: URLResponse?
+  private let data: Data?
+  private let fakedError: Error?
+  private let completionHandler: (Data?, URLResponse?, Error?) -> Void
+
+  public init(
+    urlResponse: URLResponse?,
+    data: Data?,
+    error: Error?,
+    completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void
+  ) {
+    self.urlResponse = urlResponse
+    self.data = data
+    self.fakedError = error
+    self.completionHandler = completionHandler
+  }
+
+  public override func resume() {
+    completionHandler(data, urlResponse, fakedError)
+  }
+}

--- a/Tests/PayID/PayIDClientTest.swift
+++ b/Tests/PayID/PayIDClientTest.swift
@@ -1,60 +1,6 @@
 import XCTest
 import XpringKit
 
-/// A fake URLSession that will return data tasks which will call completion handlers with the given parameters.
-public class FakeURLSession: URLSession {
-  public var urlResponse: URLResponse?
-  public var data: Data?
-  public var error: Error?
-
-  public convenience init(string: String, urlResponse: HTTPURLResponse?, error: Error?) {
-    let data = string.data(using: .utf8)
-    self.init(data: data, urlResponse: urlResponse, error: error)
-  }
-
-  public init(data: Data?, urlResponse: HTTPURLResponse?, error: Error?) {
-    self.data = data
-    self.urlResponse = urlResponse
-    self.error = error
-  }
-
-  public override func dataTask(
-    with request: URLRequest,
-    completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void
-  ) -> URLSessionDataTask {
-    return FakeURLSessionDataTask(
-      urlResponse: urlResponse,
-      data: data,
-      error: error,
-      completionHandler: completionHandler
-    )
-  }
-}
-
-/// A fake data task that will immediately call completion.
-public class FakeURLSessionDataTask: URLSessionDataTask {
-  private let urlResponse: URLResponse?
-  private let data: Data?
-  private let fakedError: Error?
-  private let completionHandler: (Data?, URLResponse?, Error?) -> Void
-
-  public init(
-    urlResponse: URLResponse?,
-    data: Data?,
-    error: Error?,
-    completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void
-    ) {
-    self.urlResponse = urlResponse
-    self.data = data
-    self.fakedError = error
-    self.completionHandler = completionHandler
-  }
-
-  public override func resume() {
-    completionHandler(data, urlResponse, fakedError)
-  }
-}
-
 class PayIDClientTest: XCTestCase {
 
   func testXRPAddressForInvalidPayID() {

--- a/Tests/PayID/PayIDIntegrationTests.swift
+++ b/Tests/PayID/PayIDIntegrationTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+import XpringKit
+
+extension PaymentPointer {
+  /// The PayID to resolve.
+  public static let testPointer = "$doug.purdy.im"
+}
+
+/// Integration tests run against a live PayID service.
+final class PayIDIntegrationTests: XCTestCase {
+  private let payIDClient = PayIDClient()
+
+  func testResolvePaymentPointer() {
+    let expectation = XCTestExpectation(description: "resolveToXRP completion called.")
+
+    // GIVEN a Pay ID that will resolve WHEN it is resolved to an XRP address
+    payIDClient.resolveToXRP(.testPointer) { result in
+      // THEN the address is the expected value.
+      switch result {
+      case .success(let resolvedAddress):
+        XCTAssertEqual(resolvedAddress, "r9wmZ8Ctfdcr9gctT7LresUve7vs14ADcz")
+      case .failure(let error):
+        XCTFail("Failed to resolve address: \(error)")
+      }
+
+      expectation.fulfill()
+    }
+
+    self.wait(for: [ expectation ], timeout: 60)
+  }
+
+  // TODO(keefertaylor): Add a test for a PayID mapping which doesn't exist. https://doug.purdy.im returns 403 errors
+  // for paths which do not exist, rather than 404s.
+}

--- a/XpringKit.xcodeproj/project.pbxproj
+++ b/XpringKit.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		4060097AAC967721CFA653BB /* TransactionHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C2BF0895DEDD1C9AB5D2D /* TransactionHash.swift */; };
 		418FA404281A1EB7FC192194 /* JavaScriptUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E0C0E9FDF3E68693B2C4B9 /* JavaScriptUtils.swift */; };
 		4358ECC24A624D8C4C3F9CF4 /* RandomBytesUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6652A59C1C60CE0A44DB808D /* RandomBytesUtil.swift */; };
+		448970DABE1D9571DDC30737 /* PayIDIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFBCFB507A1F64489C83C96 /* PayIDIntegrationTests.swift */; };
 		46722EC1C4D2AC45060CF679 /* DefaultIlpClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA56A942C3C3BC82B5291917 /* DefaultIlpClient.swift */; };
 		46DDF9167C9203B7ABED7591 /* account_service.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09308780C1F6342570A27026 /* account_service.pb.swift */; };
 		46EEF102881ECA8CF0604AE1 /* Rpc_V1_SubmitTransactionResponse+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61B431DE83786EBAAF1D416 /* Rpc_V1_SubmitTransactionResponse+Test.swift */; };
@@ -104,12 +105,13 @@
 		559ED2AB9EF5FD27838AA624 /* FakeNetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ACE19B61522015207CC5FB4 /* FakeNetworkClient.swift */; };
 		55CC48E792FEE0B1E2785A43 /* transaction.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458D19126E809E9EE9F0522E /* transaction.pb.swift */; };
 		567AA63408E8F1A026494AAF /* XpringKitTestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8113A7B1A4F26A434C63CDF8 /* XpringKitTestError.swift */; };
+		56EF1497C61E72ECCAE039E9 /* PayIDClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1580FB48076A062F296BE7 /* PayIDClient.swift */; };
 		574A277447AA41AF2AD7261F /* SwiftProtobuf.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1E488ABD93CCADA4769887E2 /* SwiftProtobuf.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		57942F616CED2F1FBBFB3F0E /* ilp_over_http_service.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B1D134D50D3D92485C0A63 /* ilp_over_http_service.pb.swift */; };
 		57C790A9F7337BE05048955A /* JavaScriptSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC429E0E63319A1BE3AE8240 /* JavaScriptSerializer.swift */; };
 		588081EE271A37F189B7530C /* submit_signed_transaction_response.legacy.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA52B4D0F398FE9FB0E352F /* submit_signed_transaction_response.legacy.pb.swift */; };
-		5A7B6232BC2B502B4E92B03A /* Org_Interledger_Stream_Proto_BalanceServiceServiceClient+IlpNetworkBalanceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4AC93E3B1613693F059F5C /* Org_Interledger_Stream_Proto_BalanceServiceServiceClient+IlpNetworkBalanceClient.swift */; };
 		5A5956D9E2CD9D919BE02FF6 /* XRPPathElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB22FDA177435630E3BF9EE /* XRPPathElement.swift */; };
+		5A7B6232BC2B502B4E92B03A /* Org_Interledger_Stream_Proto_BalanceServiceServiceClient+IlpNetworkBalanceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4AC93E3B1613693F059F5C /* Org_Interledger_Stream_Proto_BalanceServiceServiceClient+IlpNetworkBalanceClient.swift */; };
 		5A89E6357D16B50EA9F04548 /* Org_Xrpl_Rpc_V1_GetAccountTransactionHistoryResponse+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9903F8C2AAC8B3CF5AB634DB /* Org_Xrpl_Rpc_V1_GetAccountTransactionHistoryResponse+Test.swift */; };
 		5AF4F279844CEE90973A7B52 /* XpringIlpError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9426A3AC88FB99F3C1D651 /* XpringIlpError.swift */; };
 		5B2931FD0FA9B76E09BA277F /* SignerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B9235E33F4B53ED0FD35D50 /* SignerTests.swift */; };
@@ -124,13 +126,15 @@
 		6190F78310C3F1B2407FD3DF /* ProtocolBufferConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436EF316D97D78B4CA5A7DD0 /* ProtocolBufferConversionTests.swift */; };
 		621744E2E364A500F471DC48 /* submit.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = E059D3135F671B48CB5B6F06 /* submit.pb.swift */; };
 		6265EAADF0F49368066041F0 /* balance_service.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE280E235DBA00D9A9DEF7D9 /* balance_service.pb.swift */; };
+		642FD0965ECFD05A9E06CD2B /* PayIDClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1580FB48076A062F296BE7 /* PayIDClient.swift */; };
 		647EFEB9AEAF38D5CA4F3170 /* IlpClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212C92E14DA12887A571FAB4 /* IlpClient.swift */; };
 		66021074CD54A5CC00DC6E3C /* Org_Interledger_Stream_Proto_IlpOverHttpServiceServiceClient+IlpNetworkPaymentClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C3E96834D8E286E10FF5B71 /* Org_Interledger_Stream_Proto_IlpOverHttpServiceServiceClient+IlpNetworkPaymentClient.swift */; };
 		6653C323B87A0C403B5606DB /* get_transaction_status_request.legacy.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949D6FA55B17F1CF9C79628F /* get_transaction_status_request.legacy.pb.swift */; };
 		67839529F78EEAD34E9C3219 /* transaction.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458D19126E809E9EE9F0522E /* transaction.pb.swift */; };
 		6933342C51E08FAFA80E5244 /* Signer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C987E39201D5B0AA9E73428E /* Signer.swift */; };
-		698A28EE00473E0C1C4444B0 /* IlpNetworkBalanceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334F52A4395C8AC41032C3F1 /* IlpNetworkBalanceClient.swift */; };
 		693CAC4B65818B3E4CDBBFB5 /* XRPPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E36DFA8E7A96810E106D7E8 /* XRPPath.swift */; };
+		698A28EE00473E0C1C4444B0 /* IlpNetworkBalanceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334F52A4395C8AC41032C3F1 /* IlpNetworkBalanceClient.swift */; };
+		6A2FF3960513FB5FCF7BFE5C /* PayIDIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFBCFB507A1F64489C83C96 /* PayIDIntegrationTests.swift */; };
 		6A7BA44E08E21670FF0AB84C /* ledger_sequence.legacy.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73821CD37E7723908344FCC6 /* ledger_sequence.legacy.pb.swift */; };
 		6B85D18D3F38F8968EF41032 /* IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42C1A6AD7B7AC4F5483751E /* IntegrationTests.swift */; };
 		6C4F223CCCE03407DDB5E13E /* PaymentPointer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8177F7A2319DBD1509D6D5DF /* PaymentPointer.swift */; };
@@ -144,6 +148,7 @@
 		73A88C53338897780B4F4D15 /* send_payment_response.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F91B57A9F948372BC35757 /* send_payment_response.pb.swift */; };
 		75716AFBE3E81C8358C9D457 /* JSContext+XpringKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B600C3E787BA972AEE3194BF /* JSContext+XpringKit.swift */; };
 		7633E1E52966EB764CB50C0F /* get_balance_request.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0612C58C0F58C0667668FE96 /* get_balance_request.pb.swift */; };
+		78BD03105F29EDDF0F470EDA /* PayIDError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BEAB6B3FEB64170C01A783E /* PayIDError.swift */; };
 		79346DEC7AE431ACDBFAAA76 /* transaction_status.legacy.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F2426ACCAAFCDCD55A2685 /* transaction_status.legacy.pb.swift */; };
 		79415A03BDDA31881344FB83 /* XpringKitTestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8113A7B1A4F26A434C63CDF8 /* XpringKitTestError.swift */; };
 		795B3CB263354886D46FE4ED /* xrp_ledger.legacy.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4386C5D599B4959B89A81E5 /* xrp_ledger.legacy.pb.swift */; };
@@ -212,6 +217,7 @@
 		B453FC2D052EE1384450D631 /* LegacyFakeNetworkClient+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522FB48532E17C62F5D90BA5 /* LegacyFakeNetworkClient+Test.swift */; };
 		B525EDC4B7BBAB3CF674891F /* FakeNetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ACE19B61522015207CC5FB4 /* FakeNetworkClient.swift */; };
 		B6DA6A273206BB34926696EF /* ledger.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A7D6FA0E6E35F65229E5A1 /* ledger.pb.swift */; };
+		BA20CFF2E7CA4C4A46E9E9CF /* PayIDError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BEAB6B3FEB64170C01A783E /* PayIDError.swift */; };
 		BB7F2FBF9503319AD3D9120F /* SwiftGRPC.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 58A74192BD297BC4E78F9B95 /* SwiftGRPC.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		BBB896729D458BDE35C2C66B /* IlpNetworkPaymentClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96BB00E8F8A1000EF3B59F1 /* IlpNetworkPaymentClient.swift */; };
 		BCCC9EEFB201860BB5AF9B40 /* PayIDUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D59BF92C942B39401A02C92 /* PayIDUtilsTests.swift */; };
@@ -286,8 +292,8 @@
 		FBFC6A80BB530F2EAD404513 /* LegacyJavaScriptSigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EE7F3F2F1430E3C16BDB74F /* LegacyJavaScriptSigner.swift */; };
 		FC5E8544F2611AF66524CE40 /* ledger_objects.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E3010CCE4C84FC5266A393 /* ledger_objects.pb.swift */; };
 		FC72E5CBA4635904E636D3E9 /* payment.legacy.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7149FEE36A8532739977C5 /* payment.legacy.pb.swift */; };
-		FF18DBC0AE89D5006391BD80 /* DefaultIlpClientTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA32FFE800379858635FA6AA /* DefaultIlpClientTest.swift */; };
 		FD90EAF0DEA6DDF987345CC5 /* XRPPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E36DFA8E7A96810E106D7E8 /* XRPPath.swift */; };
+		FF18DBC0AE89D5006391BD80 /* DefaultIlpClientTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA32FFE800379858635FA6AA /* DefaultIlpClientTest.swift */; };
 		FF78A09CEC303B89851054E5 /* JSValue+JavaScriptWallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A8DF813EA75BD18BE4F7E7 /* JSValue+JavaScriptWallet.swift */; };
 		FF946D8E67246E1A83D03F0F /* amount.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 779FFD5A983DED90B4D0D534 /* amount.pb.swift */; };
 		FFDD4E05736F1A79B6DB680B /* NetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4505055EADFAE26992AF3B /* NetworkClient.swift */; };
@@ -370,6 +376,7 @@
 		334F52A4395C8AC41032C3F1 /* IlpNetworkBalanceClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IlpNetworkBalanceClient.swift; sourceTree = "<group>"; };
 		367711CBA6DD24C5C890B35F /* XRPLedgerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XRPLedgerError.swift; sourceTree = "<group>"; };
 		38E3010CCE4C84FC5266A393 /* ledger_objects.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ledger_objects.pb.swift; sourceTree = "<group>"; };
+		3C1580FB48076A062F296BE7 /* PayIDClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayIDClient.swift; sourceTree = "<group>"; };
 		3C3E96834D8E286E10FF5B71 /* Org_Interledger_Stream_Proto_IlpOverHttpServiceServiceClient+IlpNetworkPaymentClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Org_Interledger_Stream_Proto_IlpOverHttpServiceServiceClient+IlpNetworkPaymentClient.swift"; sourceTree = "<group>"; };
 		3F4AC93E3B1613693F059F5C /* Org_Interledger_Stream_Proto_BalanceServiceServiceClient+IlpNetworkBalanceClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Org_Interledger_Stream_Proto_BalanceServiceServiceClient+IlpNetworkBalanceClient.swift"; sourceTree = "<group>"; };
 		433634E362F59C8D8BFC47A2 /* currency.legacy.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = currency.legacy.pb.swift; sourceTree = "<group>"; };
@@ -407,14 +414,15 @@
 		7ACE19B61522015207CC5FB4 /* FakeNetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeNetworkClient.swift; sourceTree = "<group>"; };
 		7B9235E33F4B53ED0FD35D50 /* SignerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignerTests.swift; sourceTree = "<group>"; };
 		7CA322AED644086EF04AFD52 /* Io_Xpring_TransactionStatus+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Io_Xpring_TransactionStatus+Test.swift"; sourceTree = "<group>"; };
-		7EB336C65560B88294E5E38C /* Org_Xrpl_Rpc_V1_Payment.PathElement+XRPPathElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Org_Xrpl_Rpc_V1_Payment.PathElement+XRPPathElement.swift"; sourceTree = "<group>"; };
 		7D59BF92C942B39401A02C92 /* PayIDUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayIDUtilsTests.swift; sourceTree = "<group>"; };
+		7EB336C65560B88294E5E38C /* Org_Xrpl_Rpc_V1_Payment.PathElement+XRPPathElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Org_Xrpl_Rpc_V1_Payment.PathElement+XRPPathElement.swift"; sourceTree = "<group>"; };
 		8113A7B1A4F26A434C63CDF8 /* XpringKitTestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XpringKitTestError.swift; sourceTree = "<group>"; };
 		8177F7A2319DBD1509D6D5DF /* PaymentPointer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentPointer.swift; sourceTree = "<group>"; };
 		8561A4CDC03D07B17AAB8924 /* Address.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Address.swift; sourceTree = "<group>"; };
 		875501A3CB68BA56309F3BDF /* JavaScriptWalletGenerationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JavaScriptWalletGenerationResult.swift; sourceTree = "<group>"; };
 		87675498A19D191B1C64AF43 /* PayIDUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayIDUtils.swift; sourceTree = "<group>"; };
 		87B1D134D50D3D92485C0A63 /* ilp_over_http_service.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ilp_over_http_service.pb.swift; sourceTree = "<group>"; };
+		8BEAB6B3FEB64170C01A783E /* PayIDError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayIDError.swift; sourceTree = "<group>"; };
 		8D7CE69F01BAB5B027753EB1 /* index.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = index.js; sourceTree = "<group>"; };
 		8E9426A3AC88FB99F3C1D651 /* XpringIlpError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XpringIlpError.swift; sourceTree = "<group>"; };
 		8EE7F3F2F1430E3C16BDB74F /* LegacyJavaScriptSigner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyJavaScriptSigner.swift; sourceTree = "<group>"; };
@@ -439,6 +447,7 @@
 		B776589D95D938D60AB4917C /* SwiftGRPC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SwiftGRPC.framework; sourceTree = "<group>"; };
 		BB202B1B98F82FC7EEDA70F8 /* Rpc_V1_GetTxResponse+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Rpc_V1_GetTxResponse+Test.swift"; sourceTree = "<group>"; };
 		BC9FE3C197FEAD7C98B45EAC /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
+		BCFBCFB507A1F64489C83C96 /* PayIDIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayIDIntegrationTests.swift; sourceTree = "<group>"; };
 		BE280E235DBA00D9A9DEF7D9 /* balance_service.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = balance_service.pb.swift; sourceTree = "<group>"; };
 		C1D0F50AF49F103E1E0B3D50 /* UtilsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilsTest.swift; sourceTree = "<group>"; };
 		C437F6B8660BB13AA68CA03F /* get_balance_response.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = get_balance_response.pb.swift; sourceTree = "<group>"; };
@@ -781,6 +790,7 @@
 		BD48CE8554C5C17F3F38EB37 /* PayID */ = {
 			isa = PBXGroup;
 			children = (
+				BCFBCFB507A1F64489C83C96 /* PayIDIntegrationTests.swift */,
 				7D59BF92C942B39401A02C92 /* PayIDUtilsTests.swift */,
 			);
 			path = PayID;
@@ -868,6 +878,8 @@
 		F092B3C82CCC5697EEAFCF37 /* PayID */ = {
 			isa = PBXGroup;
 			children = (
+				3C1580FB48076A062F296BE7 /* PayIDClient.swift */,
+				8BEAB6B3FEB64170C01A783E /* PayIDError.swift */,
 				87675498A19D191B1C64AF43 /* PayIDUtils.swift */,
 				8177F7A2319DBD1509D6D5DF /* PaymentPointer.swift */,
 				7668CBA8FD05B053F3B52DBC /* JavaScript */,
@@ -1083,6 +1095,8 @@
 				CE0B5EB7A3A47BFCC11E1A69 /* Org_Xrpl_Rpc_V1_CurrencyAmount+XRPCurrency.swift in Sources */,
 				C74D038F9992E0DAF16987CD /* Org_Xrpl_Rpc_V1_Payment.Path+XRPPath.swift in Sources */,
 				CFA754A7DDEE195A70A7B0A6 /* Org_Xrpl_Rpc_V1_Payment.PathElement+XRPPathElement.swift in Sources */,
+				56EF1497C61E72ECCAE039E9 /* PayIDClient.swift in Sources */,
+				78BD03105F29EDDF0F470EDA /* PayIDError.swift in Sources */,
 				CADAC949AE0F7C8413F71680 /* PayIDUtils.swift in Sources */,
 				6C4F223CCCE03407DDB5E13E /* PaymentPointer.swift in Sources */,
 				6F01B174655CF9505B5BA44B /* RandomBytesUtil.swift in Sources */,
@@ -1102,7 +1116,6 @@
 				FB60706C284D4869588ACD12 /* XRPLedgerError.swift in Sources */,
 				FD90EAF0DEA6DDF987345CC5 /* XRPPath.swift in Sources */,
 				3B7E1F6E07976CCFFCAFA8FF /* XRPPathElement.swift in Sources */,
-				02EDB93A6C1FBF848CC8675C /* XRPTransactionType.swift in Sources */,
 				8D12BD51DEC1CDE10E7BEE66 /* XpringClient.swift in Sources */,
 				A2E0606267E284E43C0038A4 /* XpringClientDecorator.swift in Sources */,
 				3406E86051F8237DF15E6E65 /* XpringIlpError.swift in Sources */,
@@ -1177,6 +1190,7 @@
 				184FE8E7E581A3AAD65B1D0D /* LegacyFakeNetworkClient.swift in Sources */,
 				47D06DA37778837B0E6A9AA1 /* LegacySignerTest.swift in Sources */,
 				5A89E6357D16B50EA9F04548 /* Org_Xrpl_Rpc_V1_GetAccountTransactionHistoryResponse+Test.swift in Sources */,
+				448970DABE1D9571DDC30737 /* PayIDIntegrationTests.swift in Sources */,
 				94936C13496417DE22F8AE56 /* PayIDUtilsTests.swift in Sources */,
 				542830F51AF86947E5553DAE /* ProtocolBufferConversionTests.swift in Sources */,
 				53091FAF42F0CE6621FD19DF /* RawTransactionStatusTest.swift in Sources */,
@@ -1219,6 +1233,7 @@
 				A85B294480C396FE29D485FB /* LegacyFakeNetworkClient.swift in Sources */,
 				FA8ACD4B038DA24069A151B9 /* LegacySignerTest.swift in Sources */,
 				E89297B29010AACAC6D05131 /* Org_Xrpl_Rpc_V1_GetAccountTransactionHistoryResponse+Test.swift in Sources */,
+				6A2FF3960513FB5FCF7BFE5C /* PayIDIntegrationTests.swift in Sources */,
 				BCCC9EEFB201860BB5AF9B40 /* PayIDUtilsTests.swift in Sources */,
 				6190F78310C3F1B2407FD3DF /* ProtocolBufferConversionTests.swift in Sources */,
 				1931BD59C0EC20BED2B4193F /* RawTransactionStatusTest.swift in Sources */,
@@ -1275,6 +1290,8 @@
 				51EFCD74236F6C338D771D0E /* Org_Xrpl_Rpc_V1_CurrencyAmount+XRPCurrency.swift in Sources */,
 				B4522CF4706CE3E6DEBC7C24 /* Org_Xrpl_Rpc_V1_Payment.Path+XRPPath.swift in Sources */,
 				4C14ED2D1EA86A61774DA401 /* Org_Xrpl_Rpc_V1_Payment.PathElement+XRPPathElement.swift in Sources */,
+				642FD0965ECFD05A9E06CD2B /* PayIDClient.swift in Sources */,
+				BA20CFF2E7CA4C4A46E9E9CF /* PayIDError.swift in Sources */,
 				616F464F1ED2AC93FE27A9FB /* PayIDUtils.swift in Sources */,
 				1F527342583E611A058EEDAE /* PaymentPointer.swift in Sources */,
 				4358ECC24A624D8C4C3F9CF4 /* RandomBytesUtil.swift in Sources */,
@@ -1294,7 +1311,6 @@
 				E48C20215EBBCB8C44B08A0B /* XRPLedgerError.swift in Sources */,
 				693CAC4B65818B3E4CDBBFB5 /* XRPPath.swift in Sources */,
 				5A5956D9E2CD9D919BE02FF6 /* XRPPathElement.swift in Sources */,
-				733BA35B0A40C9DB41B12B58 /* XRPTransactionType.swift in Sources */,
 				3F30AAD98A595AEB8402D5A1 /* XpringClient.swift in Sources */,
 				12ADBDAD47E9B75D1515567D /* XpringClientDecorator.swift in Sources */,
 				5AF4F279844CEE90973A7B52 /* XpringIlpError.swift in Sources */,

--- a/XpringKit/PayID/PayIDClient.swift
+++ b/XpringKit/PayID/PayIDClient.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// A struct representing the response format for XRP from PayID.
+// TODO(keefertaylor): Generalize this to be more than XRP.
+private struct XRPJSONResult: Codable {
+  let address: String
+}
+
+/// Implements interaction with a PayID service.
+/// - Warning: This class is experimental and should not be used in production applications.
+public class PayIDClient {
+  public init() {}
+
+  /// Resolve the given PayID to an XRP Address.
+  ///
+  /// - Parameters
+  ///   - payID: The PayID to resolve.
+  ///   - completion: A completion block that will be called with the result of the operation.
+  public func resolveToXRP(_ payID: PaymentPointer, completion: @escaping (Result<Address?, PayIDError>) -> Void) {
+    guard let paymentPointer = PayIDUtils.parse(paymentPointer: payID) else {
+      completion(.failure(.invalidPaymentPointer(paymentPointer: payID)))
+      return
+    }
+
+    guard let url = URL(string: "https://" + paymentPointer.host + paymentPointer.path) else {
+      completion(.failure(.unknown(error: "Could not formulate PayID URL from pointer \(payID)")))
+      return
+    }
+
+    // TODO(keefertaylor): Generalize to add different headers.
+    // TODO(keefertaylor): Add network field when spec is finalized.
+    var request = URLRequest(url: url)
+    request.addValue("application/xrp+json", forHTTPHeaderField: "Accept")
+
+    URLSession.shared.dataTask(with: request) { data, response, error in
+      guard let urlResponse = response as? HTTPURLResponse else {
+        completion(.failure(.unknown(error: "Could not formulate PayID URL from pointer \(payID)")))
+        return
+      }
+
+      switch urlResponse.statusCode {
+      // Response contained addresses
+      case 200:
+        guard
+          let addressData = data,
+          let decodedResponse = try? JSONDecoder().decode(XRPJSONResult.self, from: addressData)
+          else {
+          completion(.failure(.malformedResponse))
+          return
+        }
+
+        completion(.success(decodedResponse.address))
+        return
+      // Address mapping not found.
+      case 404:
+        completion(.success(nil))
+        return
+      // Generic error
+      default:
+        var payIDErrorInfo: String?
+        if let errorData = data {
+          payIDErrorInfo = String(data: errorData, encoding: .utf8)
+        }
+        completion(.failure(.unknown(error: payIDErrorInfo)))
+        return
+      }
+    }.resume()
+  }
+}

--- a/XpringKit/PayID/PayIDError.swift
+++ b/XpringKit/PayID/PayIDError.swift
@@ -1,0 +1,13 @@
+/// errors that originate from PayID.
+public enum PayIDError: Error {
+  /// The payment pointer was invalid.
+  /// - Parameter paymentPointer: The invalid payment pointer.
+  case invalidPaymentPointer(paymentPointer: String)
+
+  /// The response from PayID was in an unexpected format.
+  case malformedResponse
+
+  /// An unknown error occured.
+  /// - Parameter error: Details about the error.
+  case unknown(error: String?)
+}


### PR DESCRIPTION
## High Level Overview of Change

Implement `PayIDClient` for GET/read requests. 

Implement unit tests with mocked networking and integration tests which run against the `doug.purdy.im` PayID service. 

### Context of Change

This change is large to show how we will handle these requests holistically. The following components are deferred to minimize PR size / until there is a proper spec:
- `network` parameters
- parsing of the response

Note that I haven't updated docs / changelog since I think this feature is still in flux / not worth mentioning. 

One thing I'm not sure about is whether to call `$keefertaylor.com/keefer` a `PayID` or a `PaymentPointer`. As such, the class names end up somewhat mixed in code. If/When we determine a consistent terminology I can do a global find / replace. 

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Before / After

PayID client is now useable. 

## Test Plan

New unit / integration tests provided for continuous integration. 