### PR TITLE
Payment History API

### DIFF
--- a/Tests/DefaultXRPClientTest.swift
+++ b/Tests/DefaultXRPClientTest.swift
@@ -1,0 +1,494 @@
+import SwiftGRPC
+import XCTest
+@testable import XpringKit
+
+final class DefaultXRPClientTest: XCTestCase {
+  // Codes which are failures returned from the ledger.
+  private static let transactionStatusFailureCodes = [
+    "tefFAILURE", "tecCLAIM", "telBAD_PUBLIC_KEY", "temBAD_FEE", "terRETRY"
+  ]
+
+  // MARK: - Balance
+  func testGetBalanceWithSuccess() {
+    // GIVEN an XRPClient which will successfully return a balance from a mocked network call.
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+
+    // WHEN the balance is requested.
+    guard let balance = try? xrpClient.getBalance(for: .testAddress) else {
+      XCTFail("Exception should not be thrown when trying to get a balance")
+      return
+    }
+
+    // THEN the balance is correct.
+    XCTAssertEqual(balance, .testBalance)
+  }
+
+  func testGetBalanceWithClassicAddress() {
+    // GIVEN a classic address.
+    guard let classicAddressComponents = Utils.decode(xAddress: .testAddress) else {
+      XCTFail("Failed to decode X-Address.")
+      return
+    }
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+
+    // WHEN the balance is requested THEN an error is thrown.
+    XCTAssertThrowsError(
+      try xrpClient.getBalance(for: classicAddressComponents.classicAddress),
+      "Exception not thrown"
+    ) { error in
+      guard
+        case .invalidInputs = error as? XRPLedgerError
+        else {
+          XCTFail("Error thrown was not invalid inputs error")
+          return
+      }
+
+    }
+  }
+
+  func testGetBalanceWithFailure() {
+    // GIVEN an XRPClient client which will throw an error when a balance is requested.
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .failure(XpringKitTestError.mockFailure),
+      feeResult: .success(.testGetFeeResponse),
+      submitTransactionResult: .success(.testSubmitTransactionResponse),
+      transactionStatusResult: .success(.testGetTransactionResponse),
+      transactionHistoryResult: .success(.testTransactionHistoryResponse)
+    )
+    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+    // WHEN the balance is requested THEN the error is thrown.
+    XCTAssertThrowsError(try xrpClient.getBalance(for: .testAddress), "Exception not thrown") { error in
+      guard
+        let _ = error as? XpringKitTestError
+        else {
+          XCTFail("Error thrown was not mocked error")
+          return
+      }
+    }
+  }
+
+  // MARK: - Send
+  func testSendWithSuccess() {
+    // GIVEN an XRPClient client which will successfully return a balance from a mocked network call.
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+
+    // WHEN XRP is sent.
+    guard
+      let transactionHash = try? xrpClient.send(
+        .testSendAmount,
+        to: .testAddress,
+        from: .testWallet)
+      else {
+        XCTFail("Exception should not be thrown when trying to send XRP")
+        return
+    }
+
+    // THEN the engine result code is as expected.
+    XCTAssertEqual(transactionHash, TransactionHash.testTransactionHash)
+  }
+
+  func testSendWithClassicAddress() {
+    // GIVEN a classic address.
+    guard let classicAddressComponents = Utils.decode(xAddress: .testAddress) else {
+      XCTFail("Failed to decode X - Address.")
+      return
+    }
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+
+    // WHEN XRP is sent to a classic address THEN an error is thrown.
+    XCTAssertThrowsError(try xrpClient.send(
+      .testSendAmount,
+      to: classicAddressComponents.classicAddress,
+      from: .testWallet
+      ))
+  }
+
+  func testSendWithInvalidAddress() {
+    // GIVEN an XRPClient client and an invalid destination address.
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+    let destinationAddress = "xrp"
+
+    // WHEN XRP is sent to an invalid address THEN an error is thrown.
+    XCTAssertThrowsError(try xrpClient.send(
+      .testSendAmount,
+      to: destinationAddress,
+      from: .testWallet
+      ))
+  }
+
+  func testSendWithAccountInfoFailure() {
+    // GIVEN an XRPClient client which will fail to return account info.
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .failure(XpringKitTestError.mockFailure),
+      feeResult: .success(.testGetFeeResponse),
+      submitTransactionResult: .success(.testSubmitTransactionResponse),
+      transactionStatusResult: .success(.testGetTransactionResponse),
+      transactionHistoryResult: .success(.testTransactionHistoryResponse)
+    )
+    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+    // WHEN a send is attempted then an error is thrown.
+    XCTAssertThrowsError(try xrpClient.send(
+      .testSendAmount,
+      to: .testAddress,
+      from: .testWallet
+      ))
+  }
+
+  func testSendWithFeeFailure() {
+    // GIVEN an XRPClient client which will fail to return a fee.
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .success(.testGetAccountInfoResponse),
+      feeResult: .failure(XpringKitTestError.mockFailure),
+      submitTransactionResult: .success(.testSubmitTransactionResponse),
+      transactionStatusResult: .success(.testGetTransactionResponse),
+      transactionHistoryResult: .success(.testTransactionHistoryResponse)
+    )
+    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+    // WHEN a send is attempted then an error is thrown.
+    XCTAssertThrowsError(try xrpClient.send(
+      .testSendAmount,
+      to: .testAddress,
+      from: .testWallet
+      ))
+  }
+
+  func testSendWithSubmitFailure() {
+    // GIVEN an XRPClient client which will fail to submit a transaction.
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .success(.testGetAccountInfoResponse),
+      feeResult: .success(.testGetFeeResponse),
+      submitTransactionResult: .failure(XpringKitTestError.mockFailure),
+      transactionStatusResult: .success(.testGetTransactionResponse),
+      transactionHistoryResult: .success(.testTransactionHistoryResponse)
+    )
+    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+    // WHEN a send is attempted then an error is thrown.
+    XCTAssertThrowsError(try xrpClient.send(
+      .testSendAmount,
+      to: .testAddress,
+      from: .testWallet
+      ))
+  }
+
+  // MARK: - Transaction Status
+  func testGetTransactionStatusWithUnvalidatedTransactionAndFailureCode() {
+    // Iterate over different types of transaction status codes which represent failures.
+    for transactionStatusCodeFailure in DefaultXRPClientTest.transactionStatusFailureCodes {
+      // GIVEN an XRPClient which returns an unvalidated transaction and a failed transaction status code.
+      let transactionStatusResponse = makeGetTransactionResponse(
+        validated: false,
+        resultCode: transactionStatusCodeFailure
+      )
+      let networkClient = FakeNetworkClient(
+        accountInfoResult: .success(.testGetAccountInfoResponse),
+        feeResult: .success(.testGetFeeResponse),
+        submitTransactionResult: .success(.testSubmitTransactionResponse),
+        transactionStatusResult: .success(transactionStatusResponse),
+        transactionHistoryResult: .success(.testTransactionHistoryResponse)
+      )
+      let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+      // WHEN the transaction status is retrieved.
+      let transactionStatus = try? xrpClient.getTransactionStatus(for: .testTransactionHash)
+
+      // THEN the transaction status is pending.
+      XCTAssertEqual(transactionStatus, .pending)
+    }
+  }
+
+  func testGetTransactionStatusWithUnvalidatedTransactionAndSuccessCode() {
+    // GIVEN an XRPClient which returns an unvalidated transaction and a succeeded transaction status code.
+    let transactionStatusResponse = makeGetTransactionResponse(
+      validated: false,
+      resultCode: .testTransactionStatusCodeSuccess
+    )
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .success(.testGetAccountInfoResponse),
+      feeResult: .success(.testGetFeeResponse),
+      submitTransactionResult: .success(.testSubmitTransactionResponse),
+      transactionStatusResult: .success(transactionStatusResponse),
+      transactionHistoryResult: .success(.testTransactionHistoryResponse)
+    )
+    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+    // WHEN the transaction status is retrieved.
+    let transactionStatus = try? xrpClient.getTransactionStatus(for: .testTransactionHash)
+
+    // THEN the transaction status is pending.
+    XCTAssertEqual(transactionStatus, .pending)
+  }
+
+  func testGetTransactionStatusWithValidatedTransactionAndFailureCode() {
+    // Iterate over different types of transaction status codes which represent failures.
+    for transactionStatusCodeFailure in DefaultXRPClientTest.transactionStatusFailureCodes {
+      // GIVEN an XRPClient which returns an unvalidated transaction and a failed transaction status code.
+      let transactionStatusResponse = makeGetTransactionResponse(
+        validated: true,
+        resultCode: transactionStatusCodeFailure
+      )
+      let networkClient = FakeNetworkClient(
+        accountInfoResult: .success(.testGetAccountInfoResponse),
+        feeResult: .success(.testGetFeeResponse),
+        submitTransactionResult: .success(.testSubmitTransactionResponse),
+        transactionStatusResult: .success(transactionStatusResponse),
+        transactionHistoryResult: .success(.testTransactionHistoryResponse)
+      )
+      let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+      // WHEN the transaction status is retrieved.
+      let transactionStatus = try? xrpClient.getTransactionStatus(for: .testTransactionHash)
+
+      // THEN the transaction status is failed.
+      XCTAssertEqual(transactionStatus, .failed)
+    }
+  }
+
+  func testGetTransactionStatusWithValidatedTransactionAndSuccessCode() {
+    // GIVEN an XRPClient which returns a validated transaction and a succeeded transaction status code.
+    let transactionStatusResponse = makeGetTransactionResponse(
+      validated: true,
+      resultCode: .testTransactionStatusCodeSuccess
+    )
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .success(.testGetAccountInfoResponse),
+      feeResult: .success(.testGetFeeResponse),
+      submitTransactionResult: .success(.testSubmitTransactionResponse),
+      transactionStatusResult: .success(transactionStatusResponse),
+      transactionHistoryResult: .success(.testTransactionHistoryResponse)
+    )
+    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+    // WHEN the transaction status is retrieved.
+    let transactionStatus = try? xrpClient.getTransactionStatus(for: .testTransactionHash)
+
+    // THEN the transaction status is succeeded.
+    XCTAssertEqual(transactionStatus, .succeeded)
+  }
+
+  func testGetTransactionStatusWithServerFailure() {
+    // GIVEN an XRPClient which fails to return a transaction status.
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .success(.testGetAccountInfoResponse),
+      feeResult: .success(.testGetFeeResponse),
+      submitTransactionResult: .success(.testSubmitTransactionResponse),
+      transactionStatusResult: .failure(XpringKitTestError.mockFailure),
+      transactionHistoryResult: .success(.testTransactionHistoryResponse)
+    )
+    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+    // WHEN the transaction status is retrieved THEN an error is thrown.
+    XCTAssertThrowsError(try xrpClient.getTransactionStatus(for: .testTransactionHash))
+  }
+
+  func testTransactionStatusWithUnsupportedTransactionType() {
+    // GIVEN an XRPClient which will return a non-payment type transaction.
+    let getTransactionResponse = Org_Xrpl_Rpc_V1_GetTransactionResponse.with {
+      $0.transaction = Org_Xrpl_Rpc_V1_Transaction()
+    }
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .success(.testGetAccountInfoResponse),
+      feeResult: .success(.testGetFeeResponse),
+      submitTransactionResult: .success(.testSubmitTransactionResponse),
+      transactionStatusResult: .success(getTransactionResponse),
+      transactionHistoryResult: .success(.testTransactionHistoryResponse)
+    )
+    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+    // WHEN the transaction status is retrieved.
+    let transactionStatus = try? xrpClient.getTransactionStatus(for: .testTransactionHash)
+
+    // THEN the status is UNKNOWN.
+    XCTAssertEqual(transactionStatus, .unknown)
+  }
+
+  func testTransactionStatusWithPartialPayment() {
+    // GIVEN an XRPClient which will return a partial payment type transaction.
+    let getTransactionResponse = Org_Xrpl_Rpc_V1_GetTransactionResponse.with {
+      $0.transaction = Org_Xrpl_Rpc_V1_Transaction.with {
+        $0.payment = Org_Xrpl_Rpc_V1_Payment()
+        $0.flags = Org_Xrpl_Rpc_V1_Flags.with {
+          $0.value = RippledFlags.tfPartialPayment.rawValue
+        }
+      }
+    }
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .success(.testGetAccountInfoResponse),
+      feeResult: .success(.testGetFeeResponse),
+      submitTransactionResult: .success(.testSubmitTransactionResponse),
+      transactionStatusResult: .success(getTransactionResponse),
+      transactionHistoryResult: .success(.testTransactionHistoryResponse)
+    )
+    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+    // WHEN the transaction status is retrieved.
+    let transactionStatus = try? xrpClient.getTransactionStatus(for: .testTransactionHash)
+
+    // THEN the status is UNKNOWN.
+    XCTAssertEqual(transactionStatus, .unknown)
+  }
+
+  // MARK: - Account Existence
+  func testAccountExistsWithSuccess() {
+    // GIVEN an XRPClient which will successfully return a balance from a mocked network call.
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+
+    // WHEN the existence of the account is checked.
+    guard let exists = try? xrpClient.accountExists(for: .testAddress) else {
+      XCTFail("Exception should not be thrown when checking existence of valid account")
+      return
+    }
+
+    // THEN the balance is correct.
+    XCTAssertTrue(exists)
+  }
+
+  func testAccountExistsWithClassicAddress() {
+    // GIVEN a classic address.
+    guard let classicAddressComponents = Utils.decode(xAddress: .testAddress) else {
+      XCTFail("Failed to decode X-Address.")
+      return
+    }
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+
+    // WHEN the account's existence is checked THEN an error is thrown.
+    XCTAssertThrowsError(
+      try xrpClient.accountExists(for: classicAddressComponents.classicAddress),
+      "Exception not thrown"
+    ) { error in
+      guard
+        case .invalidInputs = error as? XRPLedgerError
+      else {
+        XCTFail("Error thrown was not invalid inputs error")
+        return
+      }
+    }
+  }
+
+  func testAccountExistsWithNotFoundFailure() {
+    // GIVEN an XRPClient which will throw an RPCError w/ StatusCode notFound when a balance is requested.
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .failure(RPCError.callError(CallResult(success: false, statusCode: StatusCode.notFound, statusMessage: "Mocked RPCError w/ notFound StatusCode", resultData: nil, initialMetadata: nil, trailingMetadata: nil))),
+      feeResult: .success(.testGetFeeResponse),
+      submitTransactionResult: .success(.testSubmitTransactionResponse),
+      transactionStatusResult: .success(.testGetTransactionResponse),
+      transactionHistoryResult: .success(.testTransactionHistoryResponse)
+    )
+    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+    // WHEN the existence of the account is checked
+    guard let exists = try? xrpClient.accountExists(for: .testAddress) else {
+      XCTFail("Exception should not be thrown when checking existence of non-existent account")
+      return
+    }
+
+    // THEN false is returned.
+    XCTAssertFalse(exists)
+  }
+
+  func testAccountExistsWithUnknownFailure() {
+    // GIVEN an XRPClient which will throw an RPCError w/ StatusCode unknown when a balance is requested.
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .failure(RPCError.callError(CallResult(success: false, statusCode: StatusCode.unknown, statusMessage: "Mocked RPCError w/ unknown StatusCode", resultData: nil, initialMetadata: nil, trailingMetadata: nil))),
+      feeResult: .success(.testGetFeeResponse),
+      submitTransactionResult: .success(.testSubmitTransactionResponse),
+      transactionStatusResult: .success(.testGetTransactionResponse),
+      transactionHistoryResult: .success(.testTransactionHistoryResponse)
+    )
+    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+    // WHEN the account's existence is checked THEN the error is re-thrown.
+    XCTAssertThrowsError(
+      try xrpClient.accountExists(for: .testAddress),
+      "Exception not thrown"
+    ) { error in
+      guard
+        case .callError = error as? RPCError
+      else {
+        XCTFail("Error thrown was not RPCError.callError")
+        return
+      }
+    }
+  }
+
+  // MARK: - TransactionHistory
+  func testTransactionHistoryWithSuccess() {
+    // GIVEN an XRPClient client which will successfully return a transactionHistory mocked network call.
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+
+    // WHEN the transactionHistory is requested.
+    guard let transactions = try? xrpClient.getTransactionHistory(for: .testAddress) else {
+      XCTFail("Exception should not be thrown when trying to get a balance")
+      return
+    }
+
+    // THEN the balance is correct.
+    XCTAssertEqual(transactions, .testTransactions)
+  }
+
+  func testGetTransactionHistoryWithClassicAddress() {
+    // GIVEN a classic address.
+    guard let classicAddressComponents = Utils.decode(xAddress: .testAddress) else {
+      XCTFail("Failed to decode X-Address.")
+      return
+    }
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+
+    // WHEN the transaction history is requested THEN an error is thrown.
+    XCTAssertThrowsError(
+      try xrpClient.getTransactionHistory(for: classicAddressComponents.classicAddress),
+      "Exception not thrown"
+    ) { error in
+      guard
+        case .invalidInputs = error as? XRPLedgerError
+      else {
+        XCTFail("Error thrown was not invalid inputs error")
+        return
+      }
+
+    }
+  }
+
+  func testGetTransactionHistoryWithFailure() {
+    // GIVEN an XRPClient client which will throw an error when a balance is requested.
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .success(.testGetAccountInfoResponse),
+      feeResult: .success(.testGetFeeResponse),
+      submitTransactionResult: .success(.testSubmitTransactionResponse),
+      transactionStatusResult: .success(.testGetTransactionResponse),
+      transactionHistoryResult: .failure(XpringKitTestError.mockFailure)
+    )
+    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+    // WHEN the transaction history is requested THEN an error is thrown.
+    XCTAssertThrowsError(try xrpClient.getTransactionHistory(for: .testAddress), "Exception not thrown") { error in
+      guard
+        let _ = error as? XpringKitTestError
+      else {
+        XCTFail("Error thrown was not mocked error")
+        return
+      }
+    }
+  }
+
+  // MARK: - Helpers
+  private func makeGetTransactionResponse(
+    validated: Bool,
+    resultCode: String
+  ) -> Org_Xrpl_Rpc_V1_GetTransactionResponse {
+    return Org_Xrpl_Rpc_V1_GetTransactionResponse.with {
+      $0.validated = validated
+      $0.meta = Org_Xrpl_Rpc_V1_Meta.with {
+        $0.transactionResult = Org_Xrpl_Rpc_V1_TransactionResult.with {
+          $0.result = resultCode
+        }
+      }
+      $0.transaction = Org_Xrpl_Rpc_V1_Transaction.with {
+        $0.payment = Org_Xrpl_Rpc_V1_Payment()
+      }
+    }
+  }
+}

--- a/Tests/Helpers/Org_Xrpl_Rpc_V1_GetAccountTransactionHistoryResponse+Test.swift
+++ b/Tests/Helpers/Org_Xrpl_Rpc_V1_GetAccountTransactionHistoryResponse+Test.swift
@@ -9,13 +9,10 @@ extension Org_Xrpl_Rpc_V1_GetAccountTransactionHistoryResponse {
 
     $0.transactions = [
       Org_Xrpl_Rpc_V1_GetTransactionResponse.with {
-        $0.transaction = Org_Xrpl_Rpc_V1_Transaction.with {
-          $0.account = Org_Xrpl_Rpc_V1_Account.with {
-            $0.value = Org_Xrpl_Rpc_V1_AccountAddress.with {
-              $0.address = .testAddress
-            }
-          }
-        }
+        $0.transaction = .testTransaction
+      },
+      Org_Xrpl_Rpc_V1_GetTransactionResponse.with {
+        $0.transaction = .testTransaction
       }
     ]
   }

--- a/Tests/Helpers/TransactionArray+Test.swift
+++ b/Tests/Helpers/TransactionArray+Test.swift
@@ -1,5 +1,8 @@
-import XpringKit
-
-extension Array where Element == XRPTransaction {
-  static let testTransactions: [XRPTransaction] = [ .testTransaction, .testTransaction ]
-}
+//@testable import XpringKit
+//
+//extension Array where Element == XRPTransaction {
+//  static let testTransactions: [XRPTransaction] =
+//    Org_Xrpl_Rpc_V1_GetAccountTransactionHistoryResponse.testTransactionHistoryResponse.transactions.map { transactionResponse in
+//    return XRPTransaction(transaction: transactionResponse.transaction)!
+//    }
+//}

--- a/XpringKit.xcodeproj/project.pbxproj
+++ b/XpringKit.xcodeproj/project.pbxproj
@@ -158,6 +158,7 @@
 		647EFEB9AEAF38D5CA4F3170 /* IlpClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212C92E14DA12887A571FAB4 /* IlpClient.swift */; };
 		66021074CD54A5CC00DC6E3C /* Org_Interledger_Stream_Proto_IlpOverHttpServiceServiceClient+IlpNetworkPaymentClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C3E96834D8E286E10FF5B71 /* Org_Interledger_Stream_Proto_IlpOverHttpServiceServiceClient+IlpNetworkPaymentClient.swift */; };
 		6653C323B87A0C403B5606DB /* get_transaction_status_request.legacy.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949D6FA55B17F1CF9C79628F /* get_transaction_status_request.legacy.pb.swift */; };
+		6769E14FDE6703B679C71D20 /* DefaultXRPClientTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA158D7B2CE015FD85B49545 /* DefaultXRPClientTest.swift */; };
 		67839529F78EEAD34E9C3219 /* transaction.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458D19126E809E9EE9F0522E /* transaction.pb.swift */; };
 		678B0F37EF859AEC82636E52 /* XRPSigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADEF77AA5C0021AD393BF87 /* XRPSigner.swift */; };
 		6933342C51E08FAFA80E5244 /* Signer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C987E39201D5B0AA9E73428E /* Signer.swift */; };
@@ -302,6 +303,7 @@
 		D58C2A36E92F8BE220AE2D5B /* common.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58A457DEFD87D5FF4A7B6282 /* common.pb.swift */; };
 		D63E7B41C6C7C720CB0FE589 /* LegacyDefaultXpringClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C3408A16393988DCD3648B8 /* LegacyDefaultXpringClient.swift */; };
 		D657F62289513455004921A9 /* create_account_response.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F53959EA38E3A5DED7017BF /* create_account_response.pb.swift */; };
+		D83A4953FAAE8645AEE51A75 /* DefaultXRPClientTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA158D7B2CE015FD85B49545 /* DefaultXRPClientTest.swift */; };
 		D97EF32A5C1E38669590DF51 /* xrp_ledger.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B065F20F6A6596A26A23B5A /* xrp_ledger.pb.swift */; };
 		DB26AC6D896AF31860B1CCE8 /* WalletGenerationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADD0BDE0881A1C6DDE6D939A /* WalletGenerationResult.swift */; };
 		DB45A08F8767F545846E8C8D /* transaction.legacy.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3CFA7AC834E90F09184EA40 /* transaction.legacy.pb.swift */; };
@@ -540,6 +542,7 @@
 		C96BB00E8F8A1000EF3B59F1 /* IlpNetworkPaymentClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IlpNetworkPaymentClient.swift; sourceTree = "<group>"; };
 		C987E39201D5B0AA9E73428E /* Signer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Signer.swift; sourceTree = "<group>"; };
 		CA13CCED57677FEBC27B475D /* XRPTransaction+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XRPTransaction+Test.swift"; sourceTree = "<group>"; };
+		CA158D7B2CE015FD85B49545 /* DefaultXRPClientTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultXRPClientTest.swift; sourceTree = "<group>"; };
 		CA32FFE800379858635FA6AA /* DefaultIlpClientTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultIlpClientTest.swift; sourceTree = "<group>"; };
 		CA56A942C3C3BC82B5291917 /* DefaultIlpClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultIlpClient.swift; sourceTree = "<group>"; };
 		CA80DCAD6A34B7C64853ED8C /* fee.legacy.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = fee.legacy.pb.swift; sourceTree = "<group>"; };
@@ -918,6 +921,7 @@
 			isa = PBXGroup;
 			children = (
 				CA32FFE800379858635FA6AA /* DefaultIlpClientTest.swift */,
+				CA158D7B2CE015FD85B49545 /* DefaultXRPClientTest.swift */,
 				D300276FE254845F4B571FFE /* Hex+ByteArrayTest.swift */,
 				4A3D163B09CEBBAA00F1C39B /* IlpIntegrationTests.swift */,
 				436EF316D97D78B4CA5A7DD0 /* ProtocolBufferConversionTests.swift */,
@@ -1304,6 +1308,7 @@
 				3EB4532DCEC601AEF0E1F511 /* BearerToken+Test.swift in Sources */,
 				26E489E7A27EDB433E16B895 /* Data+Test.swift in Sources */,
 				FF18DBC0AE89D5006391BD80 /* DefaultIlpClientTest.swift in Sources */,
+				6769E14FDE6703B679C71D20 /* DefaultXRPClientTest.swift in Sources */,
 				897EA2C4E392FFEB2472CB4B /* FakeIlpBalanceNetworkClient+Test.swift in Sources */,
 				ED34AFD6EF2C92BBD3DA6E34 /* FakeIlpBalanceNetworkClient.swift in Sources */,
 				6FC72342159BD52E6B1F6335 /* FakeIlpPaymentNetworkClient+Test.swift in Sources */,
@@ -1361,6 +1366,7 @@
 				05FCC66443B1FF8324283AC9 /* BearerToken+Test.swift in Sources */,
 				E663928F98A181B892F5EC73 /* Data+Test.swift in Sources */,
 				98D797AF3A336A5D3E60F6CA /* DefaultIlpClientTest.swift in Sources */,
+				D83A4953FAAE8645AEE51A75 /* DefaultXRPClientTest.swift in Sources */,
 				695E8A111BA6231E19B000D0 /* FakeIlpBalanceNetworkClient+Test.swift in Sources */,
 				59460E25FF4672CD92F4E6A3 /* FakeIlpBalanceNetworkClient.swift in Sources */,
 				10DB7A6148E30B7A06B30F33 /* FakeIlpPaymentNetworkClient+Test.swift in Sources */,


### PR DESCRIPTION
## High Level Overview of Change

Implement a public API for `paymentHistoy`. 

### Context of Change

Expose new `paymentHistory` method as a public API in XRP Client.  Wire an integration test for this functionality. 

Update CHANGELOG/README for new functionality. 

### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation Updates

## Before / After

Payment history works. 

## Test Plan

New integration test in CI. 