### PR TITLE
Re-Add Erroneously Deleted Test

### DIFF
--- a/Tests/DefaultXRPClientTest.swift
+++ b/Tests/DefaultXRPClientTest.swift
@@ -1,0 +1,495 @@
+import SwiftGRPC
+import XCTest
+@testable import XpringKit
+
+final class DefaultXRPClientTest: XCTestCase {
+  // Codes which are failures returned from the ledger.
+  private static let transactionStatusFailureCodes = [
+    "tefFAILURE", "tecCLAIM", "telBAD_PUBLIC_KEY", "temBAD_FEE", "terRETRY"
+  ]
+
+  // MARK: - Balance
+  func testGetBalanceWithSuccess() {
+    // GIVEN an XRPClient which will successfully return a balance from a mocked network call.
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+
+    // WHEN the balance is requested.
+    guard let balance = try? xrpClient.getBalance(for: .testAddress) else {
+      XCTFail("Exception should not be thrown when trying to get a balance")
+      return
+    }
+
+    // THEN the balance is correct.
+    XCTAssertEqual(balance, .testBalance)
+  }
+
+  func testGetBalanceWithClassicAddress() {
+    // GIVEN a classic address.
+    guard let classicAddressComponents = Utils.decode(xAddress: .testAddress) else {
+      XCTFail("Failed to decode X-Address.")
+      return
+    }
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+
+    // WHEN the balance is requested THEN an error is thrown.
+    XCTAssertThrowsError(
+      try xrpClient.getBalance(for: classicAddressComponents.classicAddress),
+      "Exception not thrown"
+    ) { error in
+      guard
+        case .invalidInputs = error as? XRPLedgerError
+        else {
+          XCTFail("Error thrown was not invalid inputs error")
+          return
+      }
+
+    }
+  }
+
+  func testGetBalanceWithFailure() {
+    // GIVEN an XRPClient client which will throw an error when a balance is requested.
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .failure(XpringKitTestError.mockFailure),
+      feeResult: .success(.testGetFeeResponse),
+      submitTransactionResult: .success(.testSubmitTransactionResponse),
+      transactionStatusResult: .success(.testGetTransactionResponse),
+      transactionHistoryResult: .success(.testTransactionHistoryResponse)
+    )
+    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+    // WHEN the balance is requested THEN the error is thrown.
+    XCTAssertThrowsError(try xrpClient.getBalance(for: .testAddress), "Exception not thrown") { error in
+      guard
+        let _ = error as? XpringKitTestError
+        else {
+          XCTFail("Error thrown was not mocked error")
+          return
+      }
+    }
+  }
+
+  // MARK: - Send
+  func testSendWithSuccess() {
+    // GIVEN an XRPClient client which will successfully return a balance from a mocked network call.
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+
+    // WHEN XRP is sent.
+    guard
+      let transactionHash = try? xrpClient.send(
+        .testSendAmount,
+        to: .testAddress,
+        from: .testWallet)
+      else {
+        XCTFail("Exception should not be thrown when trying to send XRP")
+        return
+    }
+
+    // THEN the engine result code is as expected.
+    XCTAssertEqual(transactionHash, TransactionHash.testTransactionHash)
+  }
+
+  func testSendWithClassicAddress() {
+    // GIVEN a classic address.
+    guard let classicAddressComponents = Utils.decode(xAddress: .testAddress) else {
+      XCTFail("Failed to decode X - Address.")
+      return
+    }
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+
+    // WHEN XRP is sent to a classic address THEN an error is thrown.
+    XCTAssertThrowsError(try xrpClient.send(
+      .testSendAmount,
+      to: classicAddressComponents.classicAddress,
+      from: .testWallet
+      ))
+  }
+
+  func testSendWithInvalidAddress() {
+    // GIVEN an XRPClient client and an invalid destination address.
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+    let destinationAddress = "xrp"
+
+    // WHEN XRP is sent to an invalid address THEN an error is thrown.
+    XCTAssertThrowsError(try xrpClient.send(
+      .testSendAmount,
+      to: destinationAddress,
+      from: .testWallet
+      ))
+  }
+
+  func testSendWithAccountInfoFailure() {
+    // GIVEN an XRPClient client which will fail to return account info.
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .failure(XpringKitTestError.mockFailure),
+      feeResult: .success(.testGetFeeResponse),
+      submitTransactionResult: .success(.testSubmitTransactionResponse),
+      transactionStatusResult: .success(.testGetTransactionResponse),
+      transactionHistoryResult: .success(.testTransactionHistoryResponse)
+    )
+    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+    // WHEN a send is attempted then an error is thrown.
+    XCTAssertThrowsError(try xrpClient.send(
+      .testSendAmount,
+      to: .testAddress,
+      from: .testWallet
+      ))
+  }
+
+  func testSendWithFeeFailure() {
+    // GIVEN an XRPClient client which will fail to return a fee.
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .success(.testGetAccountInfoResponse),
+      feeResult: .failure(XpringKitTestError.mockFailure),
+      submitTransactionResult: .success(.testSubmitTransactionResponse),
+      transactionStatusResult: .success(.testGetTransactionResponse),
+      transactionHistoryResult: .success(.testTransactionHistoryResponse)
+    )
+    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+    // WHEN a send is attempted then an error is thrown.
+    XCTAssertThrowsError(try xrpClient.send(
+      .testSendAmount,
+      to: .testAddress,
+      from: .testWallet
+      ))
+  }
+
+  func testSendWithSubmitFailure() {
+    // GIVEN an XRPClient client which will fail to submit a transaction.
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .success(.testGetAccountInfoResponse),
+      feeResult: .success(.testGetFeeResponse),
+      submitTransactionResult: .failure(XpringKitTestError.mockFailure),
+      transactionStatusResult: .success(.testGetTransactionResponse),
+      transactionHistoryResult: .success(.testTransactionHistoryResponse)
+    )
+    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+    // WHEN a send is attempted then an error is thrown.
+    XCTAssertThrowsError(try xrpClient.send(
+      .testSendAmount,
+      to: .testAddress,
+      from: .testWallet
+      ))
+  }
+
+  // MARK: - Transaction Status
+  func testGetTransactionStatusWithUnvalidatedTransactionAndFailureCode() {
+    // Iterate over different types of transaction status codes which represent failures.
+    for transactionStatusCodeFailure in DefaultXRPClientTest.transactionStatusFailureCodes {
+      // GIVEN an XRPClient which returns an unvalidated transaction and a failed transaction status code.
+      let transactionStatusResponse = makeGetTransactionResponse(
+        validated: false,
+        resultCode: transactionStatusCodeFailure
+      )
+      let networkClient = FakeNetworkClient(
+        accountInfoResult: .success(.testGetAccountInfoResponse),
+        feeResult: .success(.testGetFeeResponse),
+        submitTransactionResult: .success(.testSubmitTransactionResponse),
+        transactionStatusResult: .success(transactionStatusResponse),
+        transactionHistoryResult: .success(.testTransactionHistoryResponse)
+      )
+      let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+      // WHEN the transaction status is retrieved.
+      let transactionStatus = try? xrpClient.getTransactionStatus(for: .testTransactionHash)
+
+      // THEN the transaction status is pending.
+      XCTAssertEqual(transactionStatus, .pending)
+    }
+  }
+
+  func testGetTransactionStatusWithUnvalidatedTransactionAndSuccessCode() {
+    // GIVEN an XRPClient which returns an unvalidated transaction and a succeeded transaction status code.
+    let transactionStatusResponse = makeGetTransactionResponse(
+      validated: false,
+      resultCode: .testTransactionStatusCodeSuccess
+    )
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .success(.testGetAccountInfoResponse),
+      feeResult: .success(.testGetFeeResponse),
+      submitTransactionResult: .success(.testSubmitTransactionResponse),
+      transactionStatusResult: .success(transactionStatusResponse),
+      transactionHistoryResult: .success(.testTransactionHistoryResponse)
+    )
+    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+    // WHEN the transaction status is retrieved.
+    let transactionStatus = try? xrpClient.getTransactionStatus(for: .testTransactionHash)
+
+    // THEN the transaction status is pending.
+    XCTAssertEqual(transactionStatus, .pending)
+  }
+
+  func testGetTransactionStatusWithValidatedTransactionAndFailureCode() {
+    // Iterate over different types of transaction status codes which represent failures.
+    for transactionStatusCodeFailure in DefaultXRPClientTest.transactionStatusFailureCodes {
+      // GIVEN an XRPClient which returns an unvalidated transaction and a failed transaction status code.
+      let transactionStatusResponse = makeGetTransactionResponse(
+        validated: true,
+        resultCode: transactionStatusCodeFailure
+      )
+      let networkClient = FakeNetworkClient(
+        accountInfoResult: .success(.testGetAccountInfoResponse),
+        feeResult: .success(.testGetFeeResponse),
+        submitTransactionResult: .success(.testSubmitTransactionResponse),
+        transactionStatusResult: .success(transactionStatusResponse),
+        transactionHistoryResult: .success(.testTransactionHistoryResponse)
+      )
+      let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+      // WHEN the transaction status is retrieved.
+      let transactionStatus = try? xrpClient.getTransactionStatus(for: .testTransactionHash)
+
+      // THEN the transaction status is failed.
+      XCTAssertEqual(transactionStatus, .failed)
+    }
+  }
+
+  func testGetTransactionStatusWithValidatedTransactionAndSuccessCode() {
+    // GIVEN an XRPClient which returns a validated transaction and a succeeded transaction status code.
+    let transactionStatusResponse = makeGetTransactionResponse(
+      validated: true,
+      resultCode: .testTransactionStatusCodeSuccess
+    )
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .success(.testGetAccountInfoResponse),
+      feeResult: .success(.testGetFeeResponse),
+      submitTransactionResult: .success(.testSubmitTransactionResponse),
+      transactionStatusResult: .success(transactionStatusResponse),
+      transactionHistoryResult: .success(.testTransactionHistoryResponse)
+    )
+    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+    // WHEN the transaction status is retrieved.
+    let transactionStatus = try? xrpClient.getTransactionStatus(for: .testTransactionHash)
+
+    // THEN the transaction status is succeeded.
+    XCTAssertEqual(transactionStatus, .succeeded)
+  }
+
+  func testGetTransactionStatusWithServerFailure() {
+    // GIVEN an XRPClient which fails to return a transaction status.
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .success(.testGetAccountInfoResponse),
+      feeResult: .success(.testGetFeeResponse),
+      submitTransactionResult: .success(.testSubmitTransactionResponse),
+      transactionStatusResult: .failure(XpringKitTestError.mockFailure),
+      transactionHistoryResult: .success(.testTransactionHistoryResponse)
+    )
+    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+    // WHEN the transaction status is retrieved THEN an error is thrown.
+    XCTAssertThrowsError(try xrpClient.getTransactionStatus(for: .testTransactionHash))
+  }
+
+  func testTransactionStatusWithUnsupportedTransactionType() {
+    // GIVEN an XRPClient which will return a non-payment type transaction.
+    let getTransactionResponse = Org_Xrpl_Rpc_V1_GetTransactionResponse.with {
+      $0.transaction = Org_Xrpl_Rpc_V1_Transaction()
+    }
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .success(.testGetAccountInfoResponse),
+      feeResult: .success(.testGetFeeResponse),
+      submitTransactionResult: .success(.testSubmitTransactionResponse),
+      transactionStatusResult: .success(getTransactionResponse),
+      transactionHistoryResult: .success(.testTransactionHistoryResponse)
+    )
+    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+    // WHEN the transaction status is retrieved.
+    let transactionStatus = try? xrpClient.getTransactionStatus(for: .testTransactionHash)
+
+    // THEN the status is UNKNOWN.
+    XCTAssertEqual(transactionStatus, .unknown)
+  }
+
+  func testTransactionStatusWithPartialPayment() {
+    // GIVEN an XRPClient which will return a partial payment type transaction.
+    let getTransactionResponse = Org_Xrpl_Rpc_V1_GetTransactionResponse.with {
+      $0.transaction = Org_Xrpl_Rpc_V1_Transaction.with {
+        $0.payment = Org_Xrpl_Rpc_V1_Payment()
+        $0.flags = Org_Xrpl_Rpc_V1_Flags.with {
+          $0.value = RippledFlags.tfPartialPayment.rawValue
+        }
+      }
+    }
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .success(.testGetAccountInfoResponse),
+      feeResult: .success(.testGetFeeResponse),
+      submitTransactionResult: .success(.testSubmitTransactionResponse),
+      transactionStatusResult: .success(getTransactionResponse),
+      transactionHistoryResult: .success(.testTransactionHistoryResponse)
+    )
+    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+    // WHEN the transaction status is retrieved.
+    let transactionStatus = try? xrpClient.getTransactionStatus(for: .testTransactionHash)
+
+    // THEN the status is UNKNOWN.
+    XCTAssertEqual(transactionStatus, .unknown)
+  }
+
+  // MARK: - Account Existence
+  func testAccountExistsWithSuccess() {
+    // GIVEN an XRPClient which will successfully return a balance from a mocked network call.
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+
+    // WHEN the existence of the account is checked.
+    guard let exists = try? xrpClient.accountExists(for: .testAddress) else {
+      XCTFail("Exception should not be thrown when checking existence of valid account")
+      return
+    }
+
+    // THEN the balance is correct.
+    XCTAssertTrue(exists)
+  }
+
+  func testAccountExistsWithClassicAddress() {
+    // GIVEN a classic address.
+    guard let classicAddressComponents = Utils.decode(xAddress: .testAddress) else {
+      XCTFail("Failed to decode X-Address.")
+      return
+    }
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+
+    // WHEN the account's existence is checked THEN an error is thrown.
+    XCTAssertThrowsError(
+      try xrpClient.accountExists(for: classicAddressComponents.classicAddress),
+      "Exception not thrown"
+    ) { error in
+      guard
+        case .invalidInputs = error as? XRPLedgerError
+      else {
+        XCTFail("Error thrown was not invalid inputs error")
+        return
+      }
+    }
+  }
+
+  func testAccountExistsWithNotFoundFailure() {
+    // GIVEN an XRPClient which will throw an RPCError w/ StatusCode notFound when a balance is requested.
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .failure(RPCError.callError(CallResult(success: false, statusCode: StatusCode.notFound, statusMessage: "Mocked RPCError w/ notFound StatusCode", resultData: nil, initialMetadata: nil, trailingMetadata: nil))),
+      feeResult: .success(.testGetFeeResponse),
+      submitTransactionResult: .success(.testSubmitTransactionResponse),
+      transactionStatusResult: .success(.testGetTransactionResponse),
+      transactionHistoryResult: .success(.testTransactionHistoryResponse)
+    )
+    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+    // WHEN the existence of the account is checked
+    guard let exists = try? xrpClient.accountExists(for: .testAddress) else {
+      XCTFail("Exception should not be thrown when checking existence of non-existent account")
+      return
+    }
+
+    // THEN false is returned.
+    XCTAssertFalse(exists)
+  }
+
+  func testAccountExistsWithUnknownFailure() {
+    // GIVEN an XRPClient which will throw an RPCError w/ StatusCode unknown when a balance is requested.
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .failure(RPCError.callError(CallResult(success: false, statusCode: StatusCode.unknown, statusMessage: "Mocked RPCError w/ unknown StatusCode", resultData: nil, initialMetadata: nil, trailingMetadata: nil))),
+      feeResult: .success(.testGetFeeResponse),
+      submitTransactionResult: .success(.testSubmitTransactionResponse),
+      transactionStatusResult: .success(.testGetTransactionResponse),
+      transactionHistoryResult: .success(.testTransactionHistoryResponse)
+    )
+    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+    // WHEN the account's existence is checked THEN the error is re-thrown.
+    XCTAssertThrowsError(
+      try xrpClient.accountExists(for: .testAddress),
+      "Exception not thrown"
+    ) { error in
+      guard
+        case .callError = error as? RPCError
+      else {
+        XCTFail("Error thrown was not RPCError.callError")
+        return
+      }
+    }
+  }
+
+  // MARK: - TransactionHistory
+  func testTransactionHistoryWithSuccess() {
+    // GIVEN an XRPClient client which will successfully return a transactionHistory mocked network call.
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+
+    // WHEN the transactionHistory is requested.
+    guard let transactions = try? xrpClient.getTransactionHistory(for: .testAddress) else {
+      XCTFail("Exception should not be thrown when trying to get a balance")
+      return
+    }
+
+    // THEN the balance is correct.
+    XCTAssertEqual(transactions, .testTransactions)
+  }
+
+  func testGetTransactionHistoryWithClassicAddress() {
+    // GIVEN a classic address.
+    guard let classicAddressComponents = Utils.decode(xAddress: .testAddress) else {
+      XCTFail("Failed to decode X-Address.")
+      return
+    }
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+
+    // WHEN the transaction history is requested THEN an error is thrown.
+    XCTAssertThrowsError(
+      try xrpClient.getTransactionHistory(for: classicAddressComponents.classicAddress),
+      "Exception not thrown"
+    ) { error in
+      guard
+        case .invalidInputs = error as? XRPLedgerError
+      else {
+        XCTFail("Error thrown was not invalid inputs error")
+        return
+      }
+
+    }
+  }
+
+  func testGetTransactionHistoryWithFailure() {
+    // GIVEN an XRPClient client which will throw an error when a balance is requested.
+    let networkClient = FakeNetworkClient(
+      accountInfoResult: .success(.testGetAccountInfoResponse),
+      feeResult: .success(.testGetFeeResponse),
+      submitTransactionResult: .success(.testSubmitTransactionResponse),
+      transactionStatusResult: .success(.testGetTransactionResponse),
+      transactionHistoryResult: .failure(XpringKitTestError.mockFailure)
+    )
+    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+
+    // WHEN the transaction history is requested THEN an error is thrown.
+    XCTAssertThrowsError(try xrpClient.getTransactionHistory(for: .testAddress), "Exception not thrown") { error in
+      guard
+        let _ = error as? XpringKitTestError
+      else {
+        XCTFail("Error thrown was not mocked error")
+        return
+      }
+    }
+  }
+
+  // MARK: - Helpers
+  private func makeGetTransactionResponse(
+    validated: Bool,
+    resultCode: String
+  ) -> Org_Xrpl_Rpc_V1_GetTransactionResponse {
+    return Org_Xrpl_Rpc_V1_GetTransactionResponse.with {
+      $0.validated = validated
+      $0.meta = Org_Xrpl_Rpc_V1_Meta.with {
+        $0.transactionResult = Org_Xrpl_Rpc_V1_TransactionResult.with {
+          $0.result = resultCode
+        }
+      }
+      $0.transaction = Org_Xrpl_Rpc_V1_Transaction.with {
+        $0.payment = Org_Xrpl_Rpc_V1_Payment()
+      }
+    }
+  }
+}
+

--- a/XpringKit.xcodeproj/project.pbxproj
+++ b/XpringKit.xcodeproj/project.pbxproj
@@ -46,9 +46,9 @@
 		1995DE5C8101869990483423 /* Rpc_V1_GetAccountInfoResponse+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC6675AEE9797F5ACD3FCEA /* Rpc_V1_GetAccountInfoResponse+Test.swift */; };
 		1A247DABC8E1862F4657C0D4 /* Hex+ByteArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A5E636868E66D9F1B3C047 /* Hex+ByteArray.swift */; };
 		1A9E915DCB050311BAFC56B1 /* submit_signed_transaction_request.legacy.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0002C43479D0E7853BB1C8F5 /* submit_signed_transaction_request.legacy.pb.swift */; };
-		1ECEC6B930DB1711E469A22F /* Org_Xrpl_Rpc_V1_Memo+XRPMemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3719D429444F9E13BE09E2B /* Org_Xrpl_Rpc_V1_Memo+XRPMemo.swift */; };
 		1C6814D8954A2880ECDE5355 /* PaymentPointer+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ECF4F3AF6450DECF4DF6EA9 /* PaymentPointer+Test.swift */; };
 		1D90A76431BFAFA9C742FDA1 /* BearerToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638E420BC5B8916C1176F5A8 /* BearerToken.swift */; };
+		1ECEC6B930DB1711E469A22F /* Org_Xrpl_Rpc_V1_Memo+XRPMemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3719D429444F9E13BE09E2B /* Org_Xrpl_Rpc_V1_Memo+XRPMemo.swift */; };
 		1F527342583E611A058EEDAE /* PaymentPointer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8177F7A2319DBD1509D6D5DF /* PaymentPointer.swift */; };
 		1FA6ADEC2CAFD735AA5D1D4D /* get_transaction.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = E515153695FF610FFBA0D04D /* get_transaction.pb.swift */; };
 		203845E470989D16A042A55C /* Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCD54D1CD3F440E73218FF8B /* Hex.swift */; };
@@ -76,8 +76,8 @@
 		32D97D0E63A721CEA8E0E194 /* AccountID+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F0F394ABBB673AF8D4048B /* AccountID+Test.swift */; };
 		33DC66EC1A0EF286D0C8C099 /* get_fee_request.legacy.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F165451C299B5F03743452F3 /* get_fee_request.legacy.pb.swift */; };
 		3406E86051F8237DF15E6E65 /* XpringIlpError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9426A3AC88FB99F3C1D651 /* XpringIlpError.swift */; };
-		355021FE221CEA0CB760C0E1 /* Org_Xrpl_Rpc_V1_Memo+XRPMemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3719D429444F9E13BE09E2B /* Org_Xrpl_Rpc_V1_Memo+XRPMemo.swift */; };
 		354893EE394ED90C871C72C5 /* XRPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9A167500395386FC3A1D8F6 /* XRPClient.swift */; };
+		355021FE221CEA0CB760C0E1 /* Org_Xrpl_Rpc_V1_Memo+XRPMemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3719D429444F9E13BE09E2B /* Org_Xrpl_Rpc_V1_Memo+XRPMemo.swift */; };
 		360692E23671949068769D0C /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D4D56F206D17777FA6E54E1 /* SwiftProtobuf.framework */; };
 		36F128DA2629F5D1C8AE5020 /* PaymentPointer+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ECF4F3AF6450DECF4DF6EA9 /* PaymentPointer+Test.swift */; };
 		376D7AD384530628CC2CC2F1 /* JavaScriptSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC429E0E63319A1BE3AE8240 /* JavaScriptSerializer.swift */; };
@@ -151,6 +151,7 @@
 		647EFEB9AEAF38D5CA4F3170 /* IlpClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212C92E14DA12887A571FAB4 /* IlpClient.swift */; };
 		66021074CD54A5CC00DC6E3C /* Org_Interledger_Stream_Proto_IlpOverHttpServiceServiceClient+IlpNetworkPaymentClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C3E96834D8E286E10FF5B71 /* Org_Interledger_Stream_Proto_IlpOverHttpServiceServiceClient+IlpNetworkPaymentClient.swift */; };
 		6653C323B87A0C403B5606DB /* get_transaction_status_request.legacy.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949D6FA55B17F1CF9C79628F /* get_transaction_status_request.legacy.pb.swift */; };
+		6769E14FDE6703B679C71D20 /* DefaultXRPClientTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA158D7B2CE015FD85B49545 /* DefaultXRPClientTest.swift */; };
 		67839529F78EEAD34E9C3219 /* transaction.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458D19126E809E9EE9F0522E /* transaction.pb.swift */; };
 		678B0F37EF859AEC82636E52 /* XRPSigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADEF77AA5C0021AD393BF87 /* XRPSigner.swift */; };
 		6933342C51E08FAFA80E5244 /* Signer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C987E39201D5B0AA9E73428E /* Signer.swift */; };
@@ -165,7 +166,6 @@
 		6F01B174655CF9505B5BA44B /* RandomBytesUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6652A59C1C60CE0A44DB808D /* RandomBytesUtil.swift */; };
 		6F074F6BA2E14E92570F5009 /* BearerToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638E420BC5B8916C1176F5A8 /* BearerToken.swift */; };
 		6F45F21D33BD43E34E12D927 /* ledger_objects.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E3010CCE4C84FC5266A393 /* ledger_objects.pb.swift */; };
-		6FC8014A134DFF4C5ACFC7AE /* XRPPayment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208B11B24E3C97D246A3B79B /* XRPPayment.swift */; };
 		6FC72342159BD52E6B1F6335 /* FakeIlpPaymentNetworkClient+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45AABC76DA29DC3CD2AD93B /* FakeIlpPaymentNetworkClient+Test.swift */; };
 		6FC8014A134DFF4C5ACFC7AE /* XRPPayment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208B11B24E3C97D246A3B79B /* XRPPayment.swift */; };
 		70B59C3215BC7AB1750987CE /* get_fee_request.legacy.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F165451C299B5F03743452F3 /* get_fee_request.legacy.pb.swift */; };
@@ -196,7 +196,6 @@
 		86B2A810A7784BDA97A5A4DC /* send_payment_request.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B46264F4BC24B7608F5E9A /* send_payment_request.pb.swift */; };
 		8848947D5A23B459EBBD1C2E /* JavaScriptWalletFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6411247733F228E6454489A5 /* JavaScriptWalletFactory.swift */; };
 		8945810DE27DF575C5578692 /* send_payment_request.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B46264F4BC24B7608F5E9A /* send_payment_request.pb.swift */; };
-		89BD323C0517B92E7D7C0B74 /* Org_Xrpl_Rpc_V1_Payment+XRPPayment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311B163D0A1CDE967F2C5DFA /* Org_Xrpl_Rpc_V1_Payment+XRPPayment.swift */; };
 		897EA2C4E392FFEB2472CB4B /* FakeIlpBalanceNetworkClient+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1C7A870F6A536D32F84C5A /* FakeIlpBalanceNetworkClient+Test.swift */; };
 		89BD323C0517B92E7D7C0B74 /* Org_Xrpl_Rpc_V1_Payment+XRPPayment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311B163D0A1CDE967F2C5DFA /* Org_Xrpl_Rpc_V1_Payment+XRPPayment.swift */; };
 		8B7EC090F90B1953D7B72EF1 /* JSValue+Io_Xpring_SignedTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB8BF9E06D061BFF85455A2D /* JSValue+Io_Xpring_SignedTransaction.swift */; };
@@ -231,8 +230,8 @@
 		A089C245C857A6D53F051710 /* Org_Xrpl_Rpc_V1_Payment+XRPPayment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311B163D0A1CDE967F2C5DFA /* Org_Xrpl_Rpc_V1_Payment+XRPPayment.swift */; };
 		A09E00F6D02A7467F8F496E6 /* get_latest_validated_ledger_sequence_request.legacy.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D149151FC4BDB6710400F26 /* get_latest_validated_ledger_sequence_request.legacy.pb.swift */; };
 		A0F1F02130A238424F4D2D0C /* transaction.legacy.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3CFA7AC834E90F09184EA40 /* transaction.legacy.pb.swift */; };
-		A1D2E7D910A73C69E700409E /* XRPMemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C09E4C2721F48A85843F9E /* XRPMemo.swift */; };
 		A1D10FFE642CBB4415A7DA32 /* FakeIlpPaymentNetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC19070DF8E97E101CCACE5D /* FakeIlpPaymentNetworkClient.swift */; };
+		A1D2E7D910A73C69E700409E /* XRPMemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C09E4C2721F48A85843F9E /* XRPMemo.swift */; };
 		A4BC9C71B6DAF6FA4176F68B /* XRPClientIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7A83D4BCA01516F962F5020 /* XRPClientIntegrationTests.swift */; };
 		A616BF3A705195EF13794504 /* XRPCurrencyAmount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BAEA48B8B441D4347A4BCD8 /* XRPCurrencyAmount.swift */; };
 		A61E43257CA4507F8620B136 /* LegacySigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68F03A5FBEF34F4F59F6A489 /* LegacySigner.swift */; };
@@ -294,6 +293,7 @@
 		D58C2A36E92F8BE220AE2D5B /* common.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58A457DEFD87D5FF4A7B6282 /* common.pb.swift */; };
 		D63E7B41C6C7C720CB0FE589 /* LegacyDefaultXpringClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C3408A16393988DCD3648B8 /* LegacyDefaultXpringClient.swift */; };
 		D657F62289513455004921A9 /* create_account_response.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F53959EA38E3A5DED7017BF /* create_account_response.pb.swift */; };
+		D83A4953FAAE8645AEE51A75 /* DefaultXRPClientTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA158D7B2CE015FD85B49545 /* DefaultXRPClientTest.swift */; };
 		D97EF32A5C1E38669590DF51 /* xrp_ledger.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B065F20F6A6596A26A23B5A /* xrp_ledger.pb.swift */; };
 		DB26AC6D896AF31860B1CCE8 /* WalletGenerationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADD0BDE0881A1C6DDE6D939A /* WalletGenerationResult.swift */; };
 		DB45A08F8767F545846E8C8D /* transaction.legacy.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3CFA7AC834E90F09184EA40 /* transaction.legacy.pb.swift */; };
@@ -509,7 +509,6 @@
 		AEFA016E351D30D824FF119A /* ReliableSubmissionXpringClientTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReliableSubmissionXpringClientTest.swift; sourceTree = "<group>"; };
 		B26D12954276D34124999E61 /* Address+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Address+Test.swift"; sourceTree = "<group>"; };
 		B3719D429444F9E13BE09E2B /* Org_Xrpl_Rpc_V1_Memo+XRPMemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Org_Xrpl_Rpc_V1_Memo+XRPMemo.swift"; sourceTree = "<group>"; };
-		B42C1A6AD7B7AC4F5483751E /* IntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationTests.swift; sourceTree = "<group>"; };
 		B4386C5D599B4959B89A81E5 /* xrp_ledger.legacy.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = xrp_ledger.legacy.pb.swift; sourceTree = "<group>"; };
 		B5E48BD016CB48D6DD24AEE0 /* account_service.grpc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = account_service.grpc.swift; sourceTree = "<group>"; };
 		B600C3E787BA972AEE3194BF /* JSContext+XpringKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSContext+XpringKit.swift"; sourceTree = "<group>"; };
@@ -525,6 +524,7 @@
 		C4A1BD1E71FF2924EEB254E4 /* account_info.legacy.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = account_info.legacy.pb.swift; sourceTree = "<group>"; };
 		C96BB00E8F8A1000EF3B59F1 /* IlpNetworkPaymentClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IlpNetworkPaymentClient.swift; sourceTree = "<group>"; };
 		C987E39201D5B0AA9E73428E /* Signer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Signer.swift; sourceTree = "<group>"; };
+		CA158D7B2CE015FD85B49545 /* DefaultXRPClientTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultXRPClientTest.swift; sourceTree = "<group>"; };
 		CA32FFE800379858635FA6AA /* DefaultIlpClientTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultIlpClientTest.swift; sourceTree = "<group>"; };
 		CA56A942C3C3BC82B5291917 /* DefaultIlpClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultIlpClient.swift; sourceTree = "<group>"; };
 		CA80DCAD6A34B7C64853ED8C /* fee.legacy.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = fee.legacy.pb.swift; sourceTree = "<group>"; };
@@ -897,6 +897,7 @@
 			isa = PBXGroup;
 			children = (
 				CA32FFE800379858635FA6AA /* DefaultIlpClientTest.swift */,
+				CA158D7B2CE015FD85B49545 /* DefaultXRPClientTest.swift */,
 				D300276FE254845F4B571FFE /* Hex+ByteArrayTest.swift */,
 				4A3D163B09CEBBAA00F1C39B /* IlpIntegrationTests.swift */,
 				436EF316D97D78B4CA5A7DD0 /* ProtocolBufferConversionTests.swift */,
@@ -1280,6 +1281,7 @@
 				1053167CEB5E37D821825F29 /* Address+Test.swift in Sources */,
 				3EB4532DCEC601AEF0E1F511 /* BearerToken+Test.swift in Sources */,
 				FF18DBC0AE89D5006391BD80 /* DefaultIlpClientTest.swift in Sources */,
+				6769E14FDE6703B679C71D20 /* DefaultXRPClientTest.swift in Sources */,
 				897EA2C4E392FFEB2472CB4B /* FakeIlpBalanceNetworkClient+Test.swift in Sources */,
 				ED34AFD6EF2C92BBD3DA6E34 /* FakeIlpBalanceNetworkClient.swift in Sources */,
 				6FC72342159BD52E6B1F6335 /* FakeIlpPaymentNetworkClient+Test.swift in Sources */,
@@ -1333,6 +1335,7 @@
 				7B9ADCFF14AF87E6751F8E46 /* Address+Test.swift in Sources */,
 				05FCC66443B1FF8324283AC9 /* BearerToken+Test.swift in Sources */,
 				98D797AF3A336A5D3E60F6CA /* DefaultIlpClientTest.swift in Sources */,
+				D83A4953FAAE8645AEE51A75 /* DefaultXRPClientTest.swift in Sources */,
 				695E8A111BA6231E19B000D0 /* FakeIlpBalanceNetworkClient+Test.swift in Sources */,
 				59460E25FF4672CD92F4E6A3 /* FakeIlpBalanceNetworkClient.swift in Sources */,
 				10DB7A6148E30B7A06B30F33 /* FakeIlpPaymentNetworkClient+Test.swift in Sources */,


### PR DESCRIPTION
## High Level Overview of Change

Re-add `DefaultXRPClientTest`.

### Context of Change

#134 deprecated `XpringClient` and changed everything to be `XRPClient` instead. This change changed the implementation of `DefaultXpringClientTest` to be `DefaultXRPClientTest`. 

#147 removed `XpringClient` and it deleted a file called `DefaultXpringClientTest`, which was really `DefaultXRPClientTest`. 

This PR restores the file from #134 under a new name. It does not change logic and it makes minor changes in documentation to replace "XpringClient" with "XRPClient" where references still exist.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Before / After

Tests exist

## Test Plan

CI