### PR TITLE
Default to connecting to rippled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+- `XRPClient` now uses [rippled's protocol buffer API](https://github.com/ripple/rippled/pull/3254) rather than the legacy API. Users who wish to use the legacy API should pass `false` for `useNewProtocolBuffers` in the constructor.
+
 ### Removed
 
 - `XpringClient` is removed from XpringKit. This class has been deprecated since 1.5.0. Clients should use `XRPClient` instead.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pod 'XpringKit'
 
 Xpring SDK needs to communicate with a rippled node which has gRPC enabled. Consult the [rippled documentation](https://github.com/ripple/rippled#build-from-source) for details on how to build your own node.
 
-To get developers started right away, Xpring currently hosts nodes. These nodes are provided on a best effort basis, and may be subject to downtime. 
+To get developers started right away, Xpring currently hosts nodes. These nodes are provided on a best effort basis, and may be subject to downtime.
 
 ```
 # TestNet
@@ -132,7 +132,7 @@ wallet.verify(message, signature); // true
 ```swift
 import XpringKit
 
-let remoteURL = "grpc.xpring.tech:80"
+let remoteURL = "alpha.test.xrp.xpring.io:50051"; // TestNet URL, use alpha.xrp.xpring.io:50051 for MainNet
 let xrpClient = XRPClient(grpcURL: remoteURL)
 ```
 
@@ -144,7 +144,7 @@ A `XRPClient` can check the balance of an account on the XRP Ledger.
 import XpringKit
 
 let remoteURL = "alpha.test.xrp.xpring.io:50051"; // TestNet URL, use alpha.xrp.xpring.io:50051 for MainNet
-let xrpClient = XRPClient(grpcURL: remoteURL, useNewProtocolBuffers: true)
+let xrpClient = XRPClient(grpcURL: remoteURL)
 
 let address = "XVMFQQBMhdouRqhPMuawgBMN1AVFTofPAdRsXG5RkPtUPNQ"
 
@@ -154,7 +154,7 @@ print(balance) // Logs a balance in drops of XRP
 
 ### Checking Transaction Status
 
-A `XRPClient` can check the status of an transaction on the XRP Ledger. 
+A `XRPClient` can check the status of an transaction on the XRP Ledger.
 
 XpringKit returns the following transaction states:
 - `succeeded`: The transaction was successfully validated and applied to the XRP Ledger.
@@ -170,7 +170,7 @@ These states are determined by the `TransactionStatus` enum.
 import XpringKit
 
 let remoteURL = "alpha.test.xrp.xpring.io:50051"; // TestNet URL, use alpha.xrp.xpring.io:50051 for MainNet
-let xrpClient = XRPClient(grpcURL: remoteURL, useNewProtocolBuffers: true)
+let xrpClient = XRPClient(grpcURL: remoteURL)
 
 let transactionHash = "9FC7D277C1C8ED9CE133CC17AEA9978E71FC644CE6F5F0C8E26F1C635D97AF4A"
 
@@ -189,7 +189,7 @@ A `XRPClient` can send XRP to other accounts on the XRP Ledger.
 import XpringKit
 
 let remoteURL = "alpha.test.xrp.xpring.io:50051"; // TestNet URL, use alpha.xrp.xpring.io:50051 for MainNet
-let xrpClient = XRPClient(grpcURL: remoteURL, useNewProtocolBuffers: true)
+let xrpClient = XRPClient(grpcURL: remoteURL)
 
 // Wallet which will send XRP
 let generationResult = Wallet.generateRandomWallet()!

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ print(balance) // Logs a balance in drops of XRP
 
 ### Checking Transaction Status
 
-A `XRPClient` can check the status of an transaction on the XRP Ledger.
+An `XRPClient` can check the status of an transaction on the XRP Ledger.
 
 XpringKit returns the following transaction states:
 - `succeeded`: The transaction was successfully validated and applied to the XRP Ledger.

--- a/Tests/DefaultXRPClientTest.swift
+++ b/Tests/DefaultXRPClientTest.swift
@@ -492,4 +492,3 @@ final class DefaultXRPClientTest: XCTestCase {
     }
   }
 }
-

--- a/Tests/XRPClientIntegrationTests.swift
+++ b/Tests/XRPClientIntegrationTests.swift
@@ -19,7 +19,7 @@ extension TransactionHash {
 /// Integration tests run against a live remote client.
 final class XRPClientIntegrationTests: XCTestCase {
   private let legacyClient = XRPClient(grpcURL: .legacyRemoteURL, useNewProtocolBuffers: false)
-  private let client = XRPClient(grpcURL: .remoteURL, useNewProtocolBuffers: true)
+  private let client = XRPClient(grpcURL: .remoteURL)
 
   // MARK: - rippled Protocol Buffers
 

--- a/XpringKit/XRPClient.swift
+++ b/XpringKit/XRPClient.swift
@@ -6,8 +6,8 @@ public class XRPClient {
   ///
   /// - Parameters:
   ///   - grpcURL: A remote URL for a rippled gRPC service.
-  ///   - useNewProtocolBuffers:  If `true`, then the new protocol buffer implementation from rippled will be used. Defaults to false.
-  public init(grpcURL: String, useNewProtocolBuffers: Bool = false) {
+  ///   - useNewProtocolBuffers:  If `true`, then the new protocol buffer implementation from rippled will be used. Defaults to true.
+  public init(grpcURL: String, useNewProtocolBuffers: Bool = true) {
     let defaultClient: XRPClientDecorator = useNewProtocolBuffers ?
       DefaultXRPClient(grpcURL: grpcURL) :
       LegacyDefaultXRPClient(grpcURL: grpcURL)


### PR DESCRIPTION
## High Level Overview of Change

Change the default behavior of the SDK to connect to rippled. 

### Context of Change

We're using these protocol buffers in the Xpring Wallet and they'll be released officially in rippled 1.5. Xpring believes this implementation to be more robust and safer than the legacy API. We provide stable, well administered nodes which are hosted in our documentation.  

### Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Before / After

Users will be defaulted to a new implementation which will provide them a better and safer experience. The only change they will need to make is to change the URL they point to. 

## Test Plan

CI

## Future Tasks

This is the first step in a multi-phase turn down of legacy:
- [x] Spin up new nodes
- [x] Dogfood rippled protocol buffers in wallet system
- [x] Default to rippled implementation
- [ ] Remove legacy protocol buffers / service from Xpring-SDK
- [ ] Turn down legacy service 

