### PR TITLE
Create `getPaymentStatus`, deprecate `getTransactionStatus`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+#### Added
+- A new `getPaymentStatus` is added which retrieves the status of payment transactions.
+
+#### Deprecated
+- `getTransactionStatus` is deprecated. Please use `getPaymentStatus` instead.
+
 ### Removed
 
 - `XpringClient` is removed from XpringKit. This class has been deprecated since 1.5.0. Clients should use `XRPClient` instead.

--- a/README.md
+++ b/README.md
@@ -152,15 +152,18 @@ let balance = try! xrpClient.getBalance(for: address)
 print(balance) // Logs a balance in drops of XRP
 ```
 
-### Checking Transaction Status
+### Checking Payment Status
 
-A `XRPClient` can check the status of an transaction on the XRP Ledger. 
+A `XRPClient` can check the status of an payment on the XRP Ledger.
+
+This method can only determine the status of [payment transactions](https://xrpl.org/payment.html) which do not have the partial payment flag ([tfPartialPayment](https://xrpl.org/payment.html#payment-flags)) set.
+
 
 XpringKit returns the following transaction states:
 - `succeeded`: The transaction was successfully validated and applied to the XRP Ledger.
 - `failed:` The transaction was successfully validated but not applied to the XRP Ledger. Or the operation will never be validated.
 - `pending`: The transaction has not yet been validated, but may be validated in the future.
-- `unknown`: The transaction status could not be determined.
+- `unknown`: The transaction status could not be determined, the hash represented a non-payment type transaction, or the hash represented a transaction with the [tfPartialPayment](https://xrpl.org/payment.html#payment-flags) flag set.
 
 **Note:** For more information, see [Reliable Transaction Submission](https://xrpl.org/reliable-transaction-submission.html) and [Transaction Results](https://xrpl.org/transaction-results.html).
 
@@ -174,7 +177,7 @@ let xrpClient = XRPClient(grpcURL: remoteURL, useNewProtocolBuffers: true)
 
 let transactionHash = "9FC7D277C1C8ED9CE133CC17AEA9978E71FC644CE6F5F0C8E26F1C635D97AF4A"
 
-let transactionStatus = xrpClient.getTransactionStatus(for: transactionHash) // TransactionStatus.succeeded
+let transactionStatus = xrpClient.paymentStatus(for: transactionHash) // TransactionStatus.succeeded
 ```
 
 **Note:** The example transactionHash may lead to a "Transaction not found." error because the TestNet is regularly reset, or the accessed node may only maintain one month of history.  Recent transaction hashes can be found in the [XRP Ledger Explorer ](https://livenet.xrpl.org/).

--- a/Tests/DefaultXRPClientTest.swift
+++ b/Tests/DefaultXRPClientTest.swift
@@ -174,8 +174,9 @@ final class DefaultXRPClientTest: XCTestCase {
       ))
   }
 
-  // MARK: - Transaction Status
-  func testGetTransactionStatusWithUnvalidatedTransactionAndFailureCode() {
+  // MARK: - Payment Status
+
+  func testGetPaymentStatusWithUnvalidatedTransactionAndFailureCode() {
     // Iterate over different types of transaction status codes which represent failures.
     for transactionStatusCodeFailure in DefaultXRPClientTest.transactionStatusFailureCodes {
       // GIVEN an XRPClient which returns an unvalidated transaction and a failed transaction status code.
@@ -192,15 +193,15 @@ final class DefaultXRPClientTest: XCTestCase {
       )
       let xrpClient = DefaultXRPClient(networkClient: networkClient)
 
-      // WHEN the transaction status is retrieved.
-      let transactionStatus = try? xrpClient.getTransactionStatus(for: .testTransactionHash)
+      // WHEN the payment status is retrieved.
+      let paymentStatus = try? xrpClient.paymentStatus(for: .testTransactionHash)
 
-      // THEN the transaction status is pending.
-      XCTAssertEqual(transactionStatus, .pending)
+      // THEN the payment status is pending.
+      XCTAssertEqual(paymentStatus, .pending)
     }
   }
 
-  func testGetTransactionStatusWithUnvalidatedTransactionAndSuccessCode() {
+  func testGetPaymentStatusWithUnvalidatedTransactionAndSuccessCode() {
     // GIVEN an XRPClient which returns an unvalidated transaction and a succeeded transaction status code.
     let transactionStatusResponse = makeGetTransactionResponse(
       validated: false,
@@ -215,14 +216,14 @@ final class DefaultXRPClientTest: XCTestCase {
     )
     let xrpClient = DefaultXRPClient(networkClient: networkClient)
 
-    // WHEN the transaction status is retrieved.
-    let transactionStatus = try? xrpClient.getTransactionStatus(for: .testTransactionHash)
+    // WHEN the payment status is retrieved.
+    let paymentStatus = try? xrpClient.paymentStatus(for: .testTransactionHash)
 
-    // THEN the transaction status is pending.
-    XCTAssertEqual(transactionStatus, .pending)
+    // THEN the payment status is pending.
+    XCTAssertEqual(paymentStatus, .pending)
   }
 
-  func testGetTransactionStatusWithValidatedTransactionAndFailureCode() {
+  func testGetPaymentStatusWithValidatedTransactionAndFailureCode() {
     // Iterate over different types of transaction status codes which represent failures.
     for transactionStatusCodeFailure in DefaultXRPClientTest.transactionStatusFailureCodes {
       // GIVEN an XRPClient which returns an unvalidated transaction and a failed transaction status code.
@@ -239,15 +240,15 @@ final class DefaultXRPClientTest: XCTestCase {
       )
       let xrpClient = DefaultXRPClient(networkClient: networkClient)
 
-      // WHEN the transaction status is retrieved.
-      let transactionStatus = try? xrpClient.getTransactionStatus(for: .testTransactionHash)
+      // WHEN the payment status is retrieved.
+      let paymentStatus = try? xrpClient.paymentStatus(for: .testTransactionHash)
 
-      // THEN the transaction status is failed.
-      XCTAssertEqual(transactionStatus, .failed)
+      // THEN the payment status is failed.
+      XCTAssertEqual(paymentStatus, .failed)
     }
   }
 
-  func testGetTransactionStatusWithValidatedTransactionAndSuccessCode() {
+  func testGetPaymentStatusWithValidatedTransactionAndSuccessCode() {
     // GIVEN an XRPClient which returns a validated transaction and a succeeded transaction status code.
     let transactionStatusResponse = makeGetTransactionResponse(
       validated: true,
@@ -262,14 +263,14 @@ final class DefaultXRPClientTest: XCTestCase {
     )
     let xrpClient = DefaultXRPClient(networkClient: networkClient)
 
-    // WHEN the transaction status is retrieved.
-    let transactionStatus = try? xrpClient.getTransactionStatus(for: .testTransactionHash)
+    // WHEN the payment status is retrieved.
+    let paymentStatus = try? xrpClient.paymentStatus(for: .testTransactionHash)
 
-    // THEN the transaction status is succeeded.
-    XCTAssertEqual(transactionStatus, .succeeded)
+    // THEN the payment status is succeeded.
+    XCTAssertEqual(paymentStatus, .succeeded)
   }
 
-  func testGetTransactionStatusWithServerFailure() {
+  func testGetPaymentStatusWithServerFailure() {
     // GIVEN an XRPClient which fails to return a transaction status.
     let networkClient = FakeNetworkClient(
       accountInfoResult: .success(.testGetAccountInfoResponse),
@@ -280,11 +281,11 @@ final class DefaultXRPClientTest: XCTestCase {
     )
     let xrpClient = DefaultXRPClient(networkClient: networkClient)
 
-    // WHEN the transaction status is retrieved THEN an error is thrown.
-    XCTAssertThrowsError(try xrpClient.getTransactionStatus(for: .testTransactionHash))
+    // WHEN the payment status is retrieved THEN an error is thrown.
+    XCTAssertThrowsError(try xrpClient.paymentStatus(for: .testTransactionHash))
   }
 
-  func testTransactionStatusWithUnsupportedTransactionType() {
+  func testPaymentStatusWithUnsupportedTransactionType() {
     // GIVEN an XRPClient which will return a non-payment type transaction.
     let getTransactionResponse = Org_Xrpl_Rpc_V1_GetTransactionResponse.with {
       $0.transaction = Org_Xrpl_Rpc_V1_Transaction()
@@ -298,14 +299,14 @@ final class DefaultXRPClientTest: XCTestCase {
     )
     let xrpClient = DefaultXRPClient(networkClient: networkClient)
 
-    // WHEN the transaction status is retrieved.
-    let transactionStatus = try? xrpClient.getTransactionStatus(for: .testTransactionHash)
+    // WHEN the payment status is retrieved.
+    let paymentStatus = try? xrpClient.paymentStatus(for: .testTransactionHash)
 
     // THEN the status is UNKNOWN.
-    XCTAssertEqual(transactionStatus, .unknown)
+    XCTAssertEqual(paymentStatus, .unknown)
   }
 
-  func testTransactionStatusWithPartialPayment() {
+  func testPaymentStatusWithPartialPayment() {
     // GIVEN an XRPClient which will return a partial payment type transaction.
     let getTransactionResponse = Org_Xrpl_Rpc_V1_GetTransactionResponse.with {
       $0.transaction = Org_Xrpl_Rpc_V1_Transaction.with {
@@ -324,14 +325,15 @@ final class DefaultXRPClientTest: XCTestCase {
     )
     let xrpClient = DefaultXRPClient(networkClient: networkClient)
 
-    // WHEN the transaction status is retrieved.
-    let transactionStatus = try? xrpClient.getTransactionStatus(for: .testTransactionHash)
+    // WHEN the payment status is retrieved.
+    let paymentStatus = try? xrpClient.paymentStatus(for: .testTransactionHash)
 
     // THEN the status is UNKNOWN.
-    XCTAssertEqual(transactionStatus, .unknown)
+    XCTAssertEqual(paymentStatus, .unknown)
   }
 
   // MARK: - Account Existence
+
   func testAccountExistsWithSuccess() {
     // GIVEN an XRPClient which will successfully return a balance from a mocked network call.
     let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
@@ -492,4 +494,3 @@ final class DefaultXRPClientTest: XCTestCase {
     }
   }
 }
-

--- a/Tests/Fakes/FakeXRPClient.swift
+++ b/Tests/Fakes/FakeXRPClient.swift
@@ -6,7 +6,7 @@ public class FakeXRPClient {
   public let networkClient: LegacyNetworkClient = LegacyFakeNetworkClient.successfulFakeNetworkClient
 
   public var getBalanceValue: UInt64
-  public var transactionStatusValue: TransactionStatus
+  public var paymentStatusValue: TransactionStatus
   public var sendValue: TransactionHash
   public var latestValidatedLedgerValue: UInt32
   public var rawTransactionStatusValue: RawTransactionStatus
@@ -15,7 +15,7 @@ public class FakeXRPClient {
 
   public init(
     getBalanceValue: UInt64,
-    transactionStatusValue: TransactionStatus,
+    paymentStatusValue: TransactionStatus,
     sendValue: TransactionHash,
     latestValidatedLedgerValue: UInt32,
     rawTransactionStatusValue: RawTransactionStatus,
@@ -23,7 +23,7 @@ public class FakeXRPClient {
     accountExistsValue: Bool
   ) {
     self.getBalanceValue = getBalanceValue
-    self.transactionStatusValue = transactionStatusValue
+    self.paymentStatusValue = paymentStatusValue
     self.sendValue = sendValue
     self.latestValidatedLedgerValue = latestValidatedLedgerValue
     self.rawTransactionStatusValue = rawTransactionStatusValue
@@ -37,8 +37,8 @@ extension FakeXRPClient: XRPClientDecorator {
     return getBalanceValue
   }
 
-  public func getTransactionStatus(for transactionHash: TransactionHash) throws -> TransactionStatus {
-    return transactionStatusValue
+  public func paymentStatus(for transactionHash: TransactionHash) throws -> TransactionStatus {
+    return paymentStatusValue
   }
 
   public func send(_ amount: UInt64, to destinationAddress: Address, from sourceWallet: Wallet) throws -> TransactionHash {

--- a/Tests/Legacy/LegacyDefaultXpringClientTest.swift
+++ b/Tests/Legacy/LegacyDefaultXpringClientTest.swift
@@ -173,9 +173,9 @@ final class LegacyDefaultXRPClientTest: XCTestCase {
       ))
   }
 
-  // MARK: - Transaction Status
+  // MARK: - Payment Status
 
-  func testGetTransactionStatusWithUnvalidatedTransactionAndFailureCode() {
+  func testPaymentStatusWithUnvalidatedTransactionAndFailureCode() {
     // Iterate over different types of transaction status codes which represent failures.
     for transactionStatusCodeFailure in LegacyDefaultXRPClientTest.transactionStatusFailureCodes {
       // GIVEN an XRPClient which returns an unvalidated transaction and a failed transaction status code.
@@ -192,15 +192,15 @@ final class LegacyDefaultXRPClientTest: XCTestCase {
       )
       let xrpClient = LegacyDefaultXRPClient(networkClient: networkClient)
 
-      // WHEN the transaction status is retrieved.
-      let transactionStatus = try? xrpClient.getTransactionStatus(for: .testTransactionHash)
+      // WHEN the payment status is retrieved.
+      let paymentStatus = try? xrpClient.paymentStatus(for: .testTransactionHash)
 
-      // THEN the transaction status is pending.
-      XCTAssertEqual(transactionStatus, .pending)
+      // THEN the payment status is pending.
+      XCTAssertEqual(paymentStatus, .pending)
     }
   }
 
-  func testGetTransactionStatusWithUnvalidatedTransactionAndSuccessCode() {
+  func testPaymentStatusWithUnvalidatedTransactionAndSuccessCode() {
     // GIVEN an XRPClient which returns an unvalidated transaction and a succeeded transaction status code.
     let transactionStatusResponse = Io_Xpring_TransactionStatus.with {
       $0.validated = false
@@ -215,14 +215,14 @@ final class LegacyDefaultXRPClientTest: XCTestCase {
     )
     let xrpClient = LegacyDefaultXRPClient(networkClient: networkClient)
 
-    // WHEN the transaction status is retrieved.
-    let transactionStatus = try? xrpClient.getTransactionStatus(for: .testTransactionHash)
+    // WHEN the payment status is retrieved.
+    let paymentStatus = try? xrpClient.paymentStatus(for: .testTransactionHash)
 
-    // THEN the transaction status is pending.
-    XCTAssertEqual(transactionStatus, .pending)
+    // THEN the payment status is pending.
+    XCTAssertEqual(paymentStatus, .pending)
   }
 
-  func testGetTransactionStatusWithValidatedTransactionAndFailureCode() {
+  func testGetPaymentStatusWithValidatedTransactionAndFailureCode() {
     // Iterate over different types of transaction status codes which represent failures.
     for transactionStatusCodeFailure in LegacyDefaultXRPClientTest.transactionStatusFailureCodes {
       // GIVEN an XRPClient which returns a validated transaction and a failed transaction status code.
@@ -239,15 +239,15 @@ final class LegacyDefaultXRPClientTest: XCTestCase {
       )
       let xrpClient = LegacyDefaultXRPClient(networkClient: networkClient)
 
-      // WHEN the transaction status is retrieved.
-      let transactionStatus = try? xrpClient.getTransactionStatus(for: .testTransactionHash)
+      // WHEN the payment status is retrieved.
+      let paymentStatus = try? xrpClient.paymentStatus(for: .testTransactionHash)
 
-      // THEN the transaction status is failed.
-      XCTAssertEqual(transactionStatus, .failed)
+      // THEN the payment status is failed.
+      XCTAssertEqual(paymentStatus, .failed)
     }
   }
 
-  func testGetTransactionStatusWithValidatedTransactionAndSuccessCode() {
+  func testGetPaymentStatusWithValidatedTransactionAndSuccessCode() {
     // GIVEN an XRPClient which returns a validated transaction and a succeeded transaction status code.
     let transactionStatusResponse = Io_Xpring_TransactionStatus.with {
       $0.validated = true
@@ -262,14 +262,14 @@ final class LegacyDefaultXRPClientTest: XCTestCase {
     )
     let xrpClient = LegacyDefaultXRPClient(networkClient: networkClient)
 
-    // WHEN the transaction status is retrieved.
-    let transactionStatus = try? xrpClient.getTransactionStatus(for: .testTransactionHash)
+    // WHEN the payment status is retrieved.
+    let paymentStatus = try? xrpClient.paymentStatus(for: .testTransactionHash)
 
-    // THEN the transaction status is succeeded.
-    XCTAssertEqual(transactionStatus, .succeeded)
+    // THEN the payment status is succeeded.
+    XCTAssertEqual(paymentStatus, .succeeded)
   }
 
-  func testGetTransactionStatusWithServerFailure() {
+  func testGetPaymentStatusWithServerFailure() {
     // GIVEN an XRPClient which fails to return a transaction status.
     let networkClient = LegacyFakeNetworkClient(
       accountInfoResult: .success(.testAccountInfo),
@@ -280,8 +280,8 @@ final class LegacyDefaultXRPClientTest: XCTestCase {
     )
     let xrpClient = LegacyDefaultXRPClient(networkClient: networkClient)
 
-    // WHEN the transaction status is retrieved THEN an error is thrown.
-    XCTAssertThrowsError(try xrpClient.getTransactionStatus(for: .testTransactionHash))
+    // WHEN the payment status is retrieved THEN an error is thrown.
+    XCTAssertThrowsError(try xrpClient.paymentStatus(for: .testTransactionHash))
   }
 
   // MARK: - Account Existence

--- a/Tests/ReliableSubmissionXpringClientTest.swift
+++ b/Tests/ReliableSubmissionXpringClientTest.swift
@@ -22,7 +22,7 @@ final class ReliableSubmissionClientTest: XCTestCase {
   override func setUp() {
     fakeXRPClient = FakeXRPClient(
       getBalanceValue: defaultBalanceValue,
-      transactionStatusValue: defaultTransactionStatusValue,
+      paymentStatusValue: defaultTransactionStatusValue,
       sendValue: defaultSendValue,
       latestValidatedLedgerValue: defaultLastestValidatedLedgerValue,
       rawTransactionStatusValue: defaultRawTransactionStatusValue,
@@ -38,9 +38,9 @@ final class ReliableSubmissionClientTest: XCTestCase {
     XCTAssertEqual(try? reliableSubmissionClient.getBalance(for: .testAddress), defaultBalanceValue)
   }
 
-  func testGetTransactionStatus() {
+  func testPaymentStatus() {
     // GIVEN a `ReliableSubmissionClient` decorating a FakeXRPClient WHEN a transaction status is retrieved THEN the result is returned unaltered.
-    XCTAssertEqual(try? reliableSubmissionClient.getTransactionStatus(for: .testTransactionHash), defaultTransactionStatusValue)
+    XCTAssertEqual(try? reliableSubmissionClient.paymentStatus(for: .testTransactionHash), defaultTransactionStatusValue)
   }
 
   func testGetLatestValidatedLedgerSequence() {

--- a/XpringKit/DefaultXRPClient.swift
+++ b/XpringKit/DefaultXRPClient.swift
@@ -75,12 +75,14 @@ extension DefaultXRPClient: XRPClientDecorator {
     return accountInfoResponse.accountData.balance.value.xrpAmount.drops
   }
 
-  /// Retrieve the transaction status for a given transaction hash.
+  /// Retrieve the transaction status for a Payment given transaction hash.
   ///
-  /// - Parameter transactionHash: The hash of the transaction.
-  /// - Throws: An error if there was a problem communicating with the XRP Ledger.
+  /// - Note: This method will only work for Payment type transactions which do not have the tf_partial_payment attribute set.
+  /// - SeeAlso: https://xrpl.org/payment.html#payment-flags
+  ///
+  /// - Parameter transactionHash The hash of the transaction.
   /// - Returns: The status of the given transaction.
-  public func getTransactionStatus(for transactionHash: TransactionHash) throws -> TransactionStatus {
+  public func paymentStatus(for transactionHash: TransactionHash) throws -> TransactionStatus {
     let transactionStatus = try getRawTransactionStatus(for: transactionHash)
 
     // Only full payment transactions can be bucketed.

--- a/XpringKit/Legacy/LegacyDefaultXpringClient.swift
+++ b/XpringKit/Legacy/LegacyDefaultXpringClient.swift
@@ -70,7 +70,7 @@ extension LegacyDefaultXRPClient: XRPClientDecorator {
   /// - Parameter transactionHash: The hash of the transaction.
   /// - Throws: An error if there was a problem communicating with the XRP Ledger.
   /// - Returns: The status of the given transaction.
-  public func getTransactionStatus(for transactionHash: TransactionHash) throws -> TransactionStatus {
+  public func paymentStatus(for transactionHash: TransactionHash) throws -> TransactionStatus {
     let transactionStatus = try getRawTransactionStatus(for: transactionHash)
 
     // Return pending if the transaction is not validated.

--- a/XpringKit/ReliableSubmissionXRPClient.swift
+++ b/XpringKit/ReliableSubmissionXRPClient.swift
@@ -14,8 +14,8 @@ extension ReliableSubmissionXRPClient: XRPClientDecorator {
     return try decoratedClient.getBalance(for: address)
   }
 
-  public func getTransactionStatus(for transactionHash: TransactionHash) throws -> TransactionStatus {
-    return try decoratedClient.getTransactionStatus(for: transactionHash)
+  public func paymentStatus(for transactionHash: TransactionHash) throws -> TransactionStatus {
+    return try decoratedClient.paymentStatus(for: transactionHash)
   }
 
   public func getLatestValidatedLedgerSequence() throws -> UInt32 {

--- a/XpringKit/XRPClient.swift
+++ b/XpringKit/XRPClient.swift
@@ -23,13 +23,26 @@ public class XRPClient {
     return try decoratedClient.getBalance(for: address)
   }
 
-  /// Retrieve the transaction status for a given transaction hash.
+  /// Retrieve the transaction status for a Payment given transaction hash.
   ///
-  /// - Parameter transactionHash: The hash of the transaction.
-  /// - Throws: An error if there was a problem communicating with the XRP Ledger.
+  /// - Note: This method will only work for Payment type transactions which do not have the tf_partial_payment attribute set.
+  /// - SeeAlso: https://xrpl.org/payment.html#payment-flags
+  ///
+  /// - Parameter transactionHash The hash of the transaction.
   /// - Returns: The status of the given transaction.
   public func getTransactionStatus(for transactionHash: TransactionHash) throws -> TransactionStatus {
-    return try decoratedClient.getTransactionStatus(for: transactionHash)
+    return try self.paymentStatus(for: transactionHash)
+  }
+
+  /// Retrieve the transaction status for a Payment given transaction hash.
+  ///
+  /// - Note: This method will only work for Payment type transactions which do not have the tf_partial_payment attribute set.
+  /// - SeeAlso: https://xrpl.org/payment.html#payment-flags
+  ///
+  /// - Parameter transactionHash The hash of the transaction.
+  /// - Returns: The status of the given transaction.
+  public func paymentStatus(for transactionHash: TransactionHash) throws -> TransactionStatus {
+    return try self.decoratedClient.paymentStatus(for: transactionHash)
   }
 
   /// Send XRP to a recipient on the XRP Ledger.

--- a/XpringKit/XRPClientDecorator.swift
+++ b/XpringKit/XRPClientDecorator.swift
@@ -7,12 +7,14 @@ public protocol XRPClientDecorator {
   /// - Returns: An unsigned integer containing the balance of the address in drops.
   func getBalance(for address: Address) throws -> UInt64
 
-  /// Retrieve the transaction status for a given transaction hash.
+  /// Retrieve the transaction status for a Payment given transaction hash.
   ///
-  /// - Parameter transactionHash: The hash of the transaction.
-  /// - Throws: An error if there was a problem communicating with the XRP Ledger.
+  /// - Note: This method will only work for Payment type transactions which do not have the tf_partial_payment attribute set.
+  /// - SeeAlso: https://xrpl.org/payment.html#payment-flags
+  ///
+  /// - Parameter transactionHash The hash of the transaction.
   /// - Returns: The status of the given transaction.
-  func getTransactionStatus(for transactionHash: TransactionHash) throws -> TransactionStatus
+  func paymentStatus(for transactionHash: TransactionHash) throws -> TransactionStatus
 
   /// Send XRP to a recipient on the XRP Ledger.
   ///


### PR DESCRIPTION
## High Level Overview of Change

This PR is a soft rename of `getTransactionStatus` to `paymentStatus`.  

JS Analog: https://github.com/xpring-eng/Xpring-JS/pull/232
Swift Analog: https://github.com/xpring-eng/xpring4j/pull/131

### Context of Change

`getTransactionStatus` can only work with Payments so we should name it appropriately.  

This change deprecates the existing method, migrates all test code and updates the changelog / documentation. 

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Before / After
Better named methods
## Test Plan
CI