### PR TITLE
Update Node Addresses to new Xpring nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pod 'XpringKit'
 
 Xpring SDK needs to communicate with a rippled node which has gRPC enabled. Consult the [rippled documentation](https://github.com/ripple/rippled#build-from-source) for details on how to build your own node.
 
-To get developers started right away, Xpring currently hosts nodes. These nodes are provided on a best effort basis, and may be subject to downtime.
+To get developers started right away, Xpring currently provides nodes:
 
 ```
 # TestNet

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ pod 'XpringKit'
 
 Xpring SDK needs to communicate with a rippled node which has gRPC enabled. Consult the [rippled documentation](https://github.com/ripple/rippled#build-from-source) for details on how to build your own node.
 
-To get developers started right away, Xpring currently hosts nodes. These nodes are provided on a best effort basis, and may be subject to downtime. 
+To get developers started right away, Xpring currently hosts nodes. These nodes are provided on a best effort basis, and may be subject to downtime.
 
 ```
 # TestNet
-alpha.test.xrp.xpring.io:50051
+test.xrp.xpring.io:50051
 
 # MainNet
-alpha.xrp.xpring.io:50051
+main.xrp.xpring.io:50051
 ```
 
 ## Usage
@@ -132,7 +132,7 @@ wallet.verify(message, signature); // true
 ```swift
 import XpringKit
 
-let remoteURL = "grpc.xpring.tech:80"
+let remoteURL = "test.xrp.xpring.io:50051"; // TestNet URL, use main.xrp.xpring.io:50051 for MainNet
 let xrpClient = XRPClient(grpcURL: remoteURL)
 ```
 
@@ -143,7 +143,7 @@ A `XRPClient` can check the balance of an account on the XRP Ledger.
 ```swift
 import XpringKit
 
-let remoteURL = "alpha.test.xrp.xpring.io:50051"; // TestNet URL, use alpha.xrp.xpring.io:50051 for MainNet
+let remoteURL = "test.xrp.xpring.io:50051"; // TestNet URL, use main.xrp.xpring.io:50051 for MainNet
 let xrpClient = XRPClient(grpcURL: remoteURL, useNewProtocolBuffers: true)
 
 let address = "XVMFQQBMhdouRqhPMuawgBMN1AVFTofPAdRsXG5RkPtUPNQ"
@@ -154,7 +154,7 @@ print(balance) // Logs a balance in drops of XRP
 
 ### Checking Transaction Status
 
-A `XRPClient` can check the status of an transaction on the XRP Ledger. 
+A `XRPClient` can check the status of an transaction on the XRP Ledger.
 
 XpringKit returns the following transaction states:
 - `succeeded`: The transaction was successfully validated and applied to the XRP Ledger.
@@ -169,7 +169,7 @@ These states are determined by the `TransactionStatus` enum.
 ```swift
 import XpringKit
 
-let remoteURL = "alpha.test.xrp.xpring.io:50051"; // TestNet URL, use alpha.xrp.xpring.io:50051 for MainNet
+let remoteURL = "test.xrp.xpring.io:50051"; // TestNet URL, use main.xrp.xpring.io:50051 for MainNet
 let xrpClient = XRPClient(grpcURL: remoteURL, useNewProtocolBuffers: true)
 
 let transactionHash = "9FC7D277C1C8ED9CE133CC17AEA9978E71FC644CE6F5F0C8E26F1C635D97AF4A"
@@ -188,7 +188,7 @@ A `XRPClient` can send XRP to other accounts on the XRP Ledger.
 ```swift
 import XpringKit
 
-let remoteURL = "alpha.test.xrp.xpring.io:50051"; // TestNet URL, use alpha.xrp.xpring.io:50051 for MainNet
+let remoteURL = "test.xrp.xpring.io:50051"; // TestNet URL, use main.xrp.xpring.io:50051 for MainNet
 let xrpClient = XRPClient(grpcURL: remoteURL, useNewProtocolBuffers: true)
 
 // Wallet which will send XRP

--- a/Tests/XRPClientIntegrationTests.swift
+++ b/Tests/XRPClientIntegrationTests.swift
@@ -13,7 +13,7 @@ extension String {
 }
 
 extension TransactionHash {
-  public static let successfulTransactionHash = "24E31668208A3165E6C702CDA66425808EAD670EABCBFA6C4403FFA93500D486"
+  public static let successfulTransactionHash = "6D9B6CDA7F6752548800C4FC14A037B8DAC2EF47E61028793768766EAB7FC81B"
 }
 
 /// Integration tests run against a live remote client.

--- a/Tests/XRPClientIntegrationTests.swift
+++ b/Tests/XRPClientIntegrationTests.swift
@@ -6,7 +6,7 @@ extension String {
   public static let legacyRemoteURL = "grpc.xpring.tech:80"
 
   /// The URL of a remote rippled node with gRPC enabled.
-  public static let remoteURL = "3.14.64.116:50051"
+  public static let remoteURL = "test.xrp.xpring.io:50051"
 
   /// An address on the chain to receive funds.
   public static let recipientAddress = "X7cBcY4bdTTzk3LHmrKAK6GyrirkXfLHGFxzke5zTmYMfw4"


### PR DESCRIPTION
## High Level Overview of Change

Xpring is hosting production grade nodes on xpring.io. Point documentation / integration tests at these nodes. 

Swift: https://github.com/xpring-eng/XpringKit/pull/155
Java:https://github.com/xpring-eng/xpring4j/pull/132
JavaScript: https://github.com/xpring-eng/Xpring-JS/pull/247

### Context of Change

Note Xpring's nodes have limited history so they don't have the old transaction hash. I grabbed a new one from Testnet.xrpl.org. 

### Type of Change

- [x] Documentation Updates

## Before / After

Better nodes, stable documentation, stable integration tests.

## Test Plan

CI