### PR TITLE
Update Docs and Credentials Logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,15 @@ test.xrp.xpring.io:50051
 main.xrp.xpring.io:50051
 ```
 
-## Usage
+### Hermes Node
+Xpring SDK's `IlpClient` needs to communicate with Xpring's ILP infrastructure through an instance of [Hermes](https://github.com/xpring-eng/hermes-ilp).   
+
+In order to connect to the Hermes instance that Xpring currently operates, you will need to create an ILP wallet [here](https://xpring.io/portal/ilp-wallet)
+
+Once your wallet has been created, you can use the gRPC URL specified in your wallet, as well as your **access token** to check your balance
+and send payments over ILP.
+
+## Usage: XRP
 
 **Note:** Xpring SDK only works with the X-Address format. For more information about this format, see the [Utilities section](#utilities) and <http://xrpaddress.info>.
 
@@ -272,6 +280,54 @@ let xAddress = Utils.encode(classicAddress: address, tag: tag) // X7jjQ4d6bz1qmj
 let classicAddressTuple = Utils.decode(xAddress: address)!
 print(classicAddressTuple.classicAddress); // rnysDDrRXxz9z66DmCmfWpq4Z5s4TyUP3G
 print(classicAddressTuple.tag); // 12345
+```
+
+## Usage: ILP
+### IlpClient
+`IlpClient` is the main interface into the ILP network.  `IlpClient` must be initialized with the URL of a Hermes instance.
+This can be found in your [wallet](https://xpring.io/portal/ilp-wallet).
+
+All calls to `IlpClient` must pass an access token, which can be generated in your [wallet](https://xpring.io/portal/ilp-wallet). 
+
+```swift
+import XpringKit
+
+let grpcUrl = "hermes-grpc-test.xpring.dev" // TestNet Hermes URL
+let ilpClient = IlpClient(grpcURL: grpcUrl)
+```
+
+#### Retreiving a Balance
+An `IlpClient` can check the balance of an account on a connector.
+
+```swift
+import XpringKit
+
+let grpcUrl = "hermes-grpc-test.xpring.dev" // TestNet Hermes URL
+let ilpClient = IlpClient(grpcURL: grpcUrl)
+
+let getBalance = try ilpClient.getBalance(for: "demo_user", withAuthorization: "2S1PZh3fEKnKg") // Just a demo user on Testnet
+print("Net balance was \(getBalance.netBalance) with asset scale \(getBalance.assetScale)")
+```
+
+#### Sending a Payment
+An `IlpClient` can send an ILP payment to another ILP address by supplying a [Payment Pointer](https://github.com/interledger/rfcs/blob/master/0026-payment-pointers/0026-payment-pointers.md)
+and a sender's account ID
+
+```swift
+import XpringKit
+
+let grpcUrl = "hermes-grpc-test.xpring.dev" // TestNet Hermes URL
+let ilpClient = IlpClient(grpcURL: grpcUrl)
+
+let paymentRequest = PaymentRequest(
+    100, 
+    to: "$xpring.money/demo_receiver", 
+    from: "demo_user"
+)
+let payment = try ilpClient.sendPayment(
+    paymentRequest,
+    withAuthorization: "2S1PZh3fEKnKg"
+)
 ```
 
 # Contributing

--- a/Tests/DefaultIlpClientTest.swift
+++ b/Tests/DefaultIlpClientTest.swift
@@ -16,7 +16,7 @@ final class DefaultIlpClientTest: XCTestCase {
         guard let balance =
             try? ilpClient.getBalance(
                 for: .testAccountID,
-                withAuthorization: .testBearerToken
+                withAuthorization: .testAccessToken
             ) else {
               XCTFail("Exception should not be thrown when trying to get a balance")
               return
@@ -40,7 +40,7 @@ final class DefaultIlpClientTest: XCTestCase {
         // WHEN the balance is requested THEN an error is thrown
         XCTAssertThrowsError(try ilpClient.getBalance(
             for: .testAccountID,
-            withAuthorization: .testBearerToken
+            withAuthorization: .testAccessToken
         ), "Exception not thrown") { error in
             guard
               let _ = error as? XpringKitTestError
@@ -69,7 +69,7 @@ final class DefaultIlpClientTest: XCTestCase {
         guard let payment: PaymentResult =
             try? ilpClient.sendPayment(
                 paymentRequest,
-                withAuthorization: .testBearerToken
+                withAuthorization: .testAccessToken
             ) else {
                 XCTFail("Exception should not be thrown when trying to send a payment")
                 return
@@ -96,7 +96,7 @@ final class DefaultIlpClientTest: XCTestCase {
         // WHEN a payment is sent THEN an error is thrown
         XCTAssertThrowsError(try ilpClient.sendPayment(
             paymentRequest,
-            withAuthorization: .testBearerToken
+            withAuthorization: .testAccessToken
         ), "Exception not thrown") { error in
             guard
               let _ = error as? XpringKitTestError

--- a/Tests/Helpers/BearerToken+Test.swift
+++ b/Tests/Helpers/BearerToken+Test.swift
@@ -1,5 +1,5 @@
 import XpringKit
 
-extension BearerToken {
-    public static let testBearerToken = "password"
+extension AccessToken {
+    public static let testAccessToken = "password"
 }

--- a/Tests/IlpCredentialsTest.swift
+++ b/Tests/IlpCredentialsTest.swift
@@ -4,7 +4,7 @@ class IlpCredentialsTest: XCTestCase {
 
     func testConstructIlpCredentialsWithoutPrefix() throws {
         // GIVEN a bearer token with no "Bearer " prefix
-        let bearerToken: String = .testBearerToken
+        let bearerToken: String = .testAccessToken
 
         // WHEN IlpCredentials are initialized
         let credentials = try IlpCredentials(bearerToken)
@@ -13,22 +13,19 @@ class IlpCredentialsTest: XCTestCase {
         // AND "Bearer " prefix has been prepended to bearerToken
         XCTAssertEqual(
             credentials.getMetadata().dictionaryRepresentation["authorization"],
-            "Bearer " + .testBearerToken
+            "Bearer " + .testAccessToken
         )
     }
 
     func testConstructIlpCredentialsWithPrefix() throws {
         // GIVEN a bearer token with a "Bearer " prefix
-        let bearerToken: String = "Bearer " + .testBearerToken
+        let bearerToken: String = "Bearer " + .testAccessToken
 
         // WHEN IlpCredentials are initialized
-        let credentials = try IlpCredentials(bearerToken)
-
-        // THEN the credentials' Metadata has an Authorization header
-        // AND its value is equal to bearerToken
-        XCTAssertEqual(
-            credentials.getMetadata().dictionaryRepresentation["authorization"],
-            bearerToken
+        // THEN an Error is thrown
+        XCTAssertThrowsError(
+            try IlpCredentials(bearerToken),
+            XpringIlpError.invalidAccessToken.localizedDescription
         )
     }
 }

--- a/Tests/IlpIntegrationTests.swift
+++ b/Tests/IlpIntegrationTests.swift
@@ -15,7 +15,7 @@ class IlpIntegrationTests: XCTestCase {
         do {
             // WHEN the balance of sdk_account1 is requested
             let balance = try ilpClient.getBalance(for: .testAccountID,
-                                                   withAuthorization: .testBearerToken)
+                                                   withAuthorization: .testAccessToken)
 
             // THEN the accountId is sdk_account1
             // AND the assetCode is "XRP"
@@ -34,6 +34,21 @@ class IlpIntegrationTests: XCTestCase {
         }
     }
 
+    func testGetBalanceWithBearerToken() {
+        // GIVEN an IlpClient with a network client hooked up to Hermes
+        // AND an ILP account with accountId = sdk_account1
+
+        // WHEN the balance of sdk_account1 is requested with an access token that starts with "Bearer "
+        // THEN an error is thrown
+        XCTAssertThrowsError(
+            try ilpClient.getBalance(
+                for: .testAccountID,
+                withAuthorization: "Bearer " + .testAccessToken
+            ),
+            XpringIlpError.invalidAccessToken.localizedDescription
+        )
+    }
+
     func testSendPayment() {
         // GIVEN an IlpClient with a network client hooked up to Hermes
         // AND an ILP account with accountId = sdk_account1
@@ -47,7 +62,7 @@ class IlpIntegrationTests: XCTestCase {
             // WHEN a payment is sent from sdk_account1 to sdk_account2
             let payment = try ilpClient.sendPayment(
                 paymentRequest,
-                withAuthorization: .testBearerToken
+                withAuthorization: .testAccessToken
             )
 
             // THEN the originalAmount is equal to the amount requested
@@ -63,4 +78,23 @@ class IlpIntegrationTests: XCTestCase {
         }
     }
 
+    func testSendPaymentWithBearerToken() {
+        // GIVEN an IlpClient with a network client hooked up to Hermes
+        // AND an ILP account with accountId = sdk_account1
+
+        // WHEN a payment is sent from sdk_account1 to sdk_account2 with an access token that starts with "Bearer "
+        // THEN an error is thrown
+        let paymentRequest = PaymentRequest(
+            .testIlpSendAmount,
+            to: .testIlpPaymentPointer,
+            from: .testAccountID
+        )
+        XCTAssertThrowsError(
+            try ilpClient.sendPayment(
+                paymentRequest,
+                withAuthorization: "Bearer " + .testAccessToken
+            ),
+            XpringIlpError.invalidAccessToken.localizedDescription
+        )
+    }
 }

--- a/XpringKit.xcodeproj/project.pbxproj
+++ b/XpringKit.xcodeproj/project.pbxproj
@@ -48,7 +48,7 @@
 		1A247DABC8E1862F4657C0D4 /* Hex+ByteArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A5E636868E66D9F1B3C047 /* Hex+ByteArray.swift */; };
 		1A9E915DCB050311BAFC56B1 /* submit_signed_transaction_request.legacy.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0002C43479D0E7853BB1C8F5 /* submit_signed_transaction_request.legacy.pb.swift */; };
 		1C6814D8954A2880ECDE5355 /* PaymentPointer+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ECF4F3AF6450DECF4DF6EA9 /* PaymentPointer+Test.swift */; };
-		1D90A76431BFAFA9C742FDA1 /* BearerToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638E420BC5B8916C1176F5A8 /* BearerToken.swift */; };
+		1D90A76431BFAFA9C742FDA1 /* AccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638E420BC5B8916C1176F5A8 /* AccessToken.swift */; };
 		1ECEC6B930DB1711E469A22F /* Org_Xrpl_Rpc_V1_Memo+XRPMemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3719D429444F9E13BE09E2B /* Org_Xrpl_Rpc_V1_Memo+XRPMemo.swift */; };
 		1F527342583E611A058EEDAE /* PaymentPointer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8177F7A2319DBD1509D6D5DF /* PaymentPointer.swift */; };
 		1FA6ADEC2CAFD735AA5D1D4D /* get_transaction.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = E515153695FF610FFBA0D04D /* get_transaction.pb.swift */; };
@@ -173,7 +173,7 @@
 		6D2F8569A6B7067F8E8C8C23 /* LegacyDefaultXpringClientTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B79DC734C8FDF8358DA1FEB /* LegacyDefaultXpringClientTest.swift */; };
 		6D311F4695A8AFCE6BF78526 /* BigInt.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A3E837E32019F19EDE7F76CC /* BigInt.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6F01B174655CF9505B5BA44B /* RandomBytesUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6652A59C1C60CE0A44DB808D /* RandomBytesUtil.swift */; };
-		6F074F6BA2E14E92570F5009 /* BearerToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638E420BC5B8916C1176F5A8 /* BearerToken.swift */; };
+		6F074F6BA2E14E92570F5009 /* AccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638E420BC5B8916C1176F5A8 /* AccessToken.swift */; };
 		6F45F21D33BD43E34E12D927 /* ledger_objects.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E3010CCE4C84FC5266A393 /* ledger_objects.pb.swift */; };
 		6FC72342159BD52E6B1F6335 /* FakeIlpPaymentNetworkClient+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45AABC76DA29DC3CD2AD93B /* FakeIlpPaymentNetworkClient+Test.swift */; };
 		6FC8014A134DFF4C5ACFC7AE /* XRPPayment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208B11B24E3C97D246A3B79B /* XRPPayment.swift */; };
@@ -482,7 +482,7 @@
 		5F53959EA38E3A5DED7017BF /* create_account_response.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = create_account_response.pb.swift; sourceTree = "<group>"; };
 		61FDE3EE16D9D9F33E1208A9 /* ilp_over_http_service.grpc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ilp_over_http_service.grpc.swift; sourceTree = "<group>"; };
 		62D8FDD6C8453C48CA406D31 /* Org_Xrpl_Rpc_V1_CurrencyAmount+XRPCurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Org_Xrpl_Rpc_V1_CurrencyAmount+XRPCurrency.swift"; sourceTree = "<group>"; };
-		638E420BC5B8916C1176F5A8 /* BearerToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BearerToken.swift; sourceTree = "<group>"; };
+		638E420BC5B8916C1176F5A8 /* AccessToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessToken.swift; sourceTree = "<group>"; };
 		63FF56FDC57281AB86816320 /* Io_Xpring_AccountInfo+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Io_Xpring_AccountInfo+Test.swift"; sourceTree = "<group>"; };
 		6411247733F228E6454489A5 /* JavaScriptWalletFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JavaScriptWalletFactory.swift; sourceTree = "<group>"; };
 		6652A59C1C60CE0A44DB808D /* RandomBytesUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomBytesUtil.swift; sourceTree = "<group>"; };
@@ -880,7 +880,7 @@
 				84DBE06824215D5500D5617B /* auth */,
 				843DF6F424194B080002710F /* model */,
 				A1BB07A638CE67FC301F0529 /* AccountID.swift */,
-				638E420BC5B8916C1176F5A8 /* BearerToken.swift */,
+				638E420BC5B8916C1176F5A8 /* AccessToken.swift */,
 				CA56A942C3C3BC82B5291917 /* DefaultIlpClient.swift */,
 				212C92E14DA12887A571FAB4 /* IlpClient.swift */,
 				56259EB063F354CA78095B0A /* IlpClientDecorator.swift */,
@@ -1230,7 +1230,7 @@
 			files = (
 				4A05DE6D9E29101AACF3DE0C /* AccountID.swift in Sources */,
 				205CE177E9CE35786EFD462D /* Address.swift in Sources */,
-				1D90A76431BFAFA9C742FDA1 /* BearerToken.swift in Sources */,
+				1D90A76431BFAFA9C742FDA1 /* AccessToken.swift in Sources */,
 				81C5E3886C4126C4CF497F8B /* ByteArray+Hex.swift in Sources */,
 				46722EC1C4D2AC45060CF679 /* DefaultIlpClient.swift in Sources */,
 				07E4E6B78EDF7EFBB5FDE645 /* DefaultXRPClient.swift in Sources */,
@@ -1476,7 +1476,7 @@
 			files = (
 				153F773D062FA9DC520B8CAC /* AccountID.swift in Sources */,
 				EBD43CC9507B11932FE0FAFA /* Address.swift in Sources */,
-				6F074F6BA2E14E92570F5009 /* BearerToken.swift in Sources */,
+				6F074F6BA2E14E92570F5009 /* AccessToken.swift in Sources */,
 				0911ACB7075E91476780E084 /* ByteArray+Hex.swift in Sources */,
 				5B6B858B8977B42DE0D1FB80 /* DefaultIlpClient.swift in Sources */,
 				468A0C007166C6E53AFEF46B /* DefaultXRPClient.swift in Sources */,

--- a/XpringKit/ILP/AccessToken.swift
+++ b/XpringKit/ILP/AccessToken.swift
@@ -1,4 +1,4 @@
 import Foundation
 
 /// A token used to authenticate to a connector account
-public typealias BearerToken = String
+public typealias AccessToken = String

--- a/XpringKit/ILP/DefaultIlpClient.swift
+++ b/XpringKit/ILP/DefaultIlpClient.swift
@@ -36,18 +36,18 @@ extension DefaultIlpClient: IlpClientDecorator {
     ///
     /// - Parameters:
     ///     -  accountID The account ID to get the balance for.
-    ///     -  bearerToken Authentication bearer token.
+    ///     -  accessToken Authentication access token. Can not start with "Bearer "
     /// - Returns: An AccountBalance with balance information of the specified account
     /// - Throws: An error If the given inputs were invalid, the account doesn't exist, or authentication failed.
     public func getBalance(for accountID: AccountID,
-                           withAuthorization bearerToken: BearerToken
+                           withAuthorization accessToken: AccessToken
     ) throws -> AccountBalance {
         let balanceRequest = Org_Interledger_Stream_Proto_GetBalanceRequest.with {
             $0.accountID = accountID
         }
         let getBalanceResponse = try self.balanceNetworkClient.getBalance(
             balanceRequest,
-            metadata: IlpCredentials(bearerToken).getMetadata()
+            metadata: IlpCredentials(accessToken).getMetadata()
         )
         return AccountBalance(getBalanceResponse: getBalanceResponse)
     }
@@ -58,16 +58,16 @@ extension DefaultIlpClient: IlpClientDecorator {
     ///         Payment status can be checked in PaymentResult.successfulPayment
     /// - Parameters:
     ///     -  paymentRequest: A PaymentRequest with options for a payment
-    ///     -  bearerToken : auth token of the sender
+    ///     -  accessToken : access token of the sender. Can not start with "Bearer "
     /// - Returns: A PaymentResult with details about the payment.
     /// - Throws: An error If the given inputs were invalid.
     public func sendPayment(_ paymentRequest: PaymentRequest,
-                            withAuthorization bearerToken: BearerToken
+                            withAuthorization accessToken: AccessToken
     ) throws -> PaymentResult {
         let paymentRequest = paymentRequest.toProto()
         let paymentResponse = try self.paymentNetworkClient.sendMoney(
             paymentRequest,
-            metadata: IlpCredentials(bearerToken).getMetadata()
+            metadata: IlpCredentials(accessToken).getMetadata()
         )
         return PaymentResult(sendPaymentResponse: paymentResponse)
     }

--- a/XpringKit/ILP/IlpClient.swift
+++ b/XpringKit/ILP/IlpClient.swift
@@ -15,13 +15,13 @@ public class IlpClient {
     ///
     /// - Parameters:
     ///     -  accountID The account ID to get the balance for.
-    ///     -  bearerToken Authentication bearer token.
+    ///     -  accessToken Authentication access token. Can not start with "Bearer "
     /// - Returns: An AccountBalance with balance information of the specified account
     /// - Throws: An error If the given inputs were invalid, the account doesn't exist, or authentication failed.
     public func getBalance(for accountID: AccountID,
-                           withAuthorization bearerToken: BearerToken
+                           withAuthorization accessToken: AccessToken
     ) throws -> AccountBalance {
-        return try decoratedClient.getBalance(for: accountID, withAuthorization: bearerToken)
+        return try decoratedClient.getBalance(for: accountID, withAuthorization: accessToken)
     }
 
     /// Send a payment from the given accountID to the destinationPaymentPointer payment pointer
@@ -30,15 +30,15 @@ public class IlpClient {
     ///         Payment status can be checked in PaymentResult.successfulPayment
     /// - Parameters:
     ///     -  paymentRequest: A PaymentRequest with options for a payment
-    ///     -  bearerToken : auth token of the sender
+    ///     -  accessToken : access token of the sender. Can not start with "Bearer "
     /// - Returns: A PaymentResult with details about the payment.
     /// - Throws: An error If the given inputs were invalid.
     public func sendPayment(_ paymentRequest: PaymentRequest,
-                            withAuthorization bearerToken: BearerToken
+                            withAuthorization accessToken: AccessToken
     ) throws -> PaymentResult {
         return try decoratedClient.sendPayment(
             paymentRequest,
-            withAuthorization: bearerToken
+            withAuthorization: accessToken
         )
     }
 }

--- a/XpringKit/ILP/IlpClientDecorator.swift
+++ b/XpringKit/ILP/IlpClientDecorator.swift
@@ -5,11 +5,11 @@ public protocol IlpClientDecorator {
     ///
     /// - Parameters:
     ///     -  accountID The account ID to get the balance for.
-    ///     -  bearerToken Authentication bearer token.
+    ///     -  accessToken Authentication access token. Can not start with "Bearer "
     /// - Returns: An AccountBalance with balance information of the specified account
     /// - Throws: An error If the given inputs were invalid, the account doesn't exist, or authentication failed.
     func getBalance(for accountID: AccountID,
-                    withAuthorization bearerToken: BearerToken
+                    withAuthorization accessToken: AccessToken
     ) throws -> AccountBalance
 
     /// Send a payment from the given accountID to the destinationPaymentPointer payment pointer
@@ -18,10 +18,10 @@ public protocol IlpClientDecorator {
     ///         Payment status can be checked in PaymentResult.successfulPayment
     /// - Parameters:
     ///     -  paymentRequest: A PaymentRequest with options for a payment
-    ///     -  bearerToken : auth token of the sender
+    ///     -  accessToken : Access token of the sender. Can not start with "Bearer "
     /// - Returns: A PaymentResult with details about the payment.
     /// - Throws: An error If the given inputs were invalid.
     func sendPayment(_ paymentRequest: PaymentRequest,
-                     withAuthorization bearerToken: BearerToken
+                     withAuthorization accessToken: AccessToken
     ) throws -> PaymentResult
 }

--- a/XpringKit/ILP/XpringIlpError.swift
+++ b/XpringKit/ILP/XpringIlpError.swift
@@ -3,4 +3,7 @@ public enum XpringIlpError: Error {
 
     /// The requested functionality is not yet implemented.
     case unimplemented
+
+    /// The access token has an invalid format, likely starts with "Bearer "
+    case invalidAccessToken
 }

--- a/XpringKit/ILP/auth/IlpCredentials.swift
+++ b/XpringKit/ILP/auth/IlpCredentials.swift
@@ -9,7 +9,7 @@ internal class IlpCredentials {
     /// Instead, it is wrapped in IlpCredentials
     private var metadata: Metadata
 
-    private let BEARER_SPACE = "Bearer "
+    private let BEARER_PREFIX = "Bearer "
 
     /// Initialize a new IlpCredentials
     /// self.metadata will be initialized and an Authorization header will be added to it.  The value
@@ -19,12 +19,12 @@ internal class IlpCredentials {
     ///     - accessToken: An access token with no "Bearer " prefix
     /// - Throws: if accessToken starts with "Bearer "
     public init(_ accessToken: String) throws {
-        if accessToken.starts(with: BEARER_SPACE) {
+        if accessToken.starts(with: BEARER_PREFIX) {
             throw XpringIlpError.invalidAccessToken
         }
 
         self.metadata = Metadata()
-        try metadata.add(key: "authorization", value: BEARER_SPACE + accessToken)
+        try metadata.add(key: "authorization", value: BEARER_PREFIX + accessToken)
     }
 
     /// Get the Metadata to pass to network calls

--- a/XpringKit/ILP/auth/IlpCredentials.swift
+++ b/XpringKit/ILP/auth/IlpCredentials.swift
@@ -9,21 +9,22 @@ internal class IlpCredentials {
     /// Instead, it is wrapped in IlpCredentials
     private var metadata: Metadata
 
+    private let BEARER_SPACE = "Bearer "
+
     /// Initialize a new IlpCredentials
     /// self.metadata will be initialized and an Authorization header will be added to it.  The value
     /// of that entry will be the bearerToken with "Bearer " prefix.
-    public init(_ bearerToken: String) throws {
-        self.metadata = Metadata()
-        try metadata.add(key: "authorization", value: self.applyBearer(bearerToken))
-    }
-
-    /// Prepends 'Bearer ' to an auth token, if it is not already prefixed with "Bearer "
     ///
     /// - Parameters:
-    ///     - token: An auth token that either does or does not have a "Bearer " prefix
-    /// - Returns: A bearer token as a String, with a "Bearer " prefix
-    private func applyBearer(_ token: String) -> String {
-        return token.starts(with: "Bearer ") ? token : "Bearer " + token
+    ///     - accessToken: An access token with no "Bearer " prefix
+    /// - Throws: if accessToken starts with "Bearer "
+    public init(_ accessToken: String) throws {
+        if accessToken.starts(with: BEARER_SPACE) {
+            throw XpringIlpError.invalidAccessToken
+        }
+
+        self.metadata = Metadata()
+        try metadata.add(key: "authorization", value: BEARER_SPACE + accessToken)
     }
 
     /// Get the Metadata to pass to network calls


### PR DESCRIPTION
## High Level Overview of Change
- Updated some swift docs to make them more accurate
- Changed `bearerToken` param names to `accessToken` (non breaking.  These have name aliases)
- IlpCredentials now throws a `XpringIlpError.invalidAccessToken` if the `accessToken` starts with `Bearer `
<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
Swift counterpart to https://github.com/xpring-eng/xpring4j/pull/147
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Refactor (non-breaking change that only restructures code)


## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
See test classes
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
