### PR TITLE
Upgrade and lock dependency versions

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-github "apple/swift-protobuf" == 1.6.0
-github "grpc/grpc-swift" == 0.9.1
-github "attaswift/bigint" == 5.0.0
+github "apple/swift-protobuf" ~> 1.6.0
+github "grpc/grpc-swift" ~> 0.9.1
+github "attaswift/bigint" ~> 5.0.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-github "apple/swift-protobuf" ~> 1.6.0
-github "grpc/grpc-swift" ~> 0.9.1
+github "apple/swift-protobuf" ~> 1.8.0
+github "grpc/grpc-swift" ~> 0.10.0
 github "attaswift/bigint" ~> 5.0.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-github "apple/swift-protobuf" ~> 1.8.0
-github "grpc/grpc-swift" ~> 0.10.0
+github "apple/swift-protobuf" ~> 1.7.0
+github "grpc/grpc-swift" ~> 0.9.1
 github "attaswift/bigint" ~> 5.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "apple/swift-protobuf" "1.6.0"
-github "attaswift/bigint" "v5.0.0"
+github "apple/swift-protobuf" "1.8.0"
+github "attaswift/bigint" "5.1.0"
 github "grpc/grpc-swift" "0.9.1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "apple/swift-protobuf" "1.8.0"
 github "attaswift/bigint" "5.1.0"
-github "grpc/grpc-swift" "0.10.0"
+github "grpc/grpc-swift" "0.9.1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "apple/swift-protobuf" "1.8.0"
 github "attaswift/bigint" "5.1.0"
-github "grpc/grpc-swift" "0.9.1"
+github "grpc/grpc-swift" "0.10.0"

--- a/XpringKit.podspec
+++ b/XpringKit.podspec
@@ -22,17 +22,17 @@ Pod::Spec.new do |spec|
   spec.source_files  = "XpringKit/**/*.swift"
   spec.resources =     [ "XpringKit/Resources/*" ]
 
-  spec.dependency 'BigInt'
-  spec.dependency 'SwiftGRPC'
-  spec.dependency 'SwiftProtobuf'
-  
+  spec.dependency 'BigInt' ~> 5.0.0
+  spec.dependency 'SwiftGRPC' ~> 0.9.1
+  spec.dependency 'SwiftProtobuf' ~> 1.6.0
+
   spec.frameworks = "Foundation"
 
   spec.test_spec "Tests" do |test_spec|
     test_spec.source_files = ["Tests/**/*.swift"]
 
-    test_spec.dependency 'BigInt'
-    
+    test_spec.dependency 'BigInt' ~> 5.0.0
+
     test_spec.frameworks = "Foundation"
   end
 end

--- a/XpringKit.podspec
+++ b/XpringKit.podspec
@@ -22,16 +22,16 @@ Pod::Spec.new do |spec|
   spec.source_files  = "XpringKit/**/*.swift"
   spec.resources =     [ "XpringKit/Resources/*" ]
 
-  spec.dependency 'BigInt' ~> 5.0.0
-  spec.dependency 'SwiftGRPC' ~> 0.9.1
-  spec.dependency 'SwiftProtobuf' ~> 1.6.0
+  spec.dependency 'BigInt', '~> 5.0.0'
+  spec.dependency 'SwiftGRPC', '~> 0.10.0'
+  spec.dependency 'SwiftProtobuf', '~> 1.7.0'
 
   spec.frameworks = "Foundation"
 
   spec.test_spec "Tests" do |test_spec|
     test_spec.source_files = ["Tests/**/*.swift"]
 
-    test_spec.dependency 'BigInt' ~> 5.0.0
+    test_spec.dependency 'BigInt', '~> 5.0.0'
 
     test_spec.frameworks = "Foundation"
   end

--- a/XpringKit.podspec
+++ b/XpringKit.podspec
@@ -23,8 +23,8 @@ Pod::Spec.new do |spec|
   spec.resources =     [ "XpringKit/Resources/*" ]
 
   spec.dependency 'BigInt', '~> 5.0.0'
-  spec.dependency 'SwiftGRPC', '~> 0.10.0'
-  spec.dependency 'SwiftProtobuf', '~> 1.7.0'
+  spec.dependency 'SwiftGRPC', '~> 0.9.1'
+  spec.dependency 'SwiftProtobuf', '~> 1.5.0'
 
   spec.frameworks = "Foundation"
 


### PR DESCRIPTION
## High Level Overview of Change

Update dependencies to latest versions and lock them. 

### Context of Change

This addresses #55. 

Note that the latest version of `SwiftgRPC` is 0.10.0 but this is incompatible with the latest XCode version when built with Carthage: https://github.com/grpc/grpc-swift/issues/615

Note that the latest version of `SwiftProtobuf` is 1.8 but we require 1.5 to be compatible with `SwiftgRPC` 0.9.1. 

Prefer using the `~>` operator over the `==` operator because it means we'll automatically get fix / minor version bumps as needed. 

See:
CocoaPods ('dependency' header): https://guides.cocoapods.org/syntax/podspec.html
Carthage ('version requirement' header): https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#cartfile

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Better control over versions. 

## Test Plan

CI