### PR TITLE
Dynamically create a transaction hash for integration tests

### DIFF
--- a/Tests/XRPClientIntegrationTests.swift
+++ b/Tests/XRPClientIntegrationTests.swift
@@ -12,10 +12,6 @@ extension String {
   public static let recipientAddress = "X7cBcY4bdTTzk3LHmrKAK6GyrirkXfLHGFxzke5zTmYMfw4"
 }
 
-extension TransactionHash {
-  public static let successfulTransactionHash = "A040256A283FA2DC1E732AF70D24DC289E6BE8B9782917F0A7FDCB23D0B48F70"
-}
-
 /// Integration tests run against a live remote client.
 final class XRPClientIntegrationTests: XCTestCase {
   private let legacyClient = XRPClient(grpcURL: .legacyRemoteURL, useNewProtocolBuffers: false)
@@ -41,7 +37,8 @@ final class XRPClientIntegrationTests: XCTestCase {
 
   func testGetTransactionStatus() {
     do {
-      let transactionStatus = try client.getTransactionStatus(for: .successfulTransactionHash)
+      let transactionHash = try client.send(.testSendAmount, to: .recipientAddress, from: .testWallet)
+      let transactionStatus = try client.getTransactionStatus(for: transactionHash)
       XCTAssertEqual(transactionStatus, .succeeded)
     } catch {
       XCTFail("Failed retrieving transaction hash with error: \(error)")
@@ -85,7 +82,8 @@ final class XRPClientIntegrationTests: XCTestCase {
 
   func testGetTransactionStatus_legacy() {
     do {
-      let transactionStatus = try legacyClient.getTransactionStatus(for: .successfulTransactionHash)
+      let transactionHash = try client.send(.testSendAmount, to: .recipientAddress, from: .testWallet)
+      let transactionStatus = try legacyClient.getTransactionStatus(for: transactionHash)
       XCTAssertEqual(transactionStatus, .succeeded)
     } catch {
       XCTFail("Failed retrieving transaction hash with error: \(error)")


### PR DESCRIPTION
## High Level Overview of Change

Create a transaction hash on the fly for integration checks rather than relying on a static hash.

### Context of Change

The Testnet nodes we use for integration tests have limited history and are reset from time to time. As a result, static hashes age out of the nodes history at least monthly, causing CI to fail.

Instead, send a payment with a known good hash and check that hash. This ensures that our hash will always be up to date. 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

No more hash refreshing check ins.

## Test Plan

CI