### PR TITLE
Add initializer for `Wallet` from public and private keys

### DIFF
--- a/Tests/WalletTest.swift
+++ b/Tests/WalletTest.swift
@@ -193,4 +193,13 @@ class WalletTest: XCTestCase {
 
     XCTAssertFalse(wallet.verify(message: message, signature: signature))
   }
+
+  func testGenerateWalletFromKeys() {
+    // GIVEN a set of well formed keys.
+    let publicKey = try! "031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE".toBytes()
+    let privateKey = try! "0090802A50AA84EFB6CDB225F17C27616EA94048C179142FECF03F4712A07EA7A4".toBytes()
+
+    // WHEN a wallet is generated THEN it is constructed successfully.
+    XCTAssertNotNil(Wallet(publicKey: publicKey, privateKey: privateKey, isTest: false))
+  }
 }

--- a/XpringKit.xcodeproj/project.pbxproj
+++ b/XpringKit.xcodeproj/project.pbxproj
@@ -911,7 +911,7 @@
 			path = model;
 			sourceTree = "<group>";
 		};
-		"TEMP_58549011-5B7F-43DA-ACF9-34D270C2D6A1" /* Legacy */ = {
+		"TEMP_5C89B876-D441-4F15-9BC6-0DD05E49018D" /* Legacy */ = {
 			isa = PBXGroup;
 			children = (
 			);

--- a/XpringKit/JavaScript/JavaScriptWalletFactory.swift
+++ b/XpringKit/JavaScript/JavaScriptWalletFactory.swift
@@ -47,6 +47,18 @@ internal class JavaScriptWalletFactory {
     return result.toWalletGenerationResult()!
   }
 
+  /// Initialize a new `Wallet` with a set of keys.
+  ///
+  /// - Parameters:
+  ///   - publicKey: Bytes representing a public key.
+  ///   - privateKey: Bytes representing a private key.
+  ///   - isTest: Whether the address is for use on a test network.
+  /// - Returns: A new wallet if inputs were valid, otherwise nil.
+  public func wallet(publicKey: [UInt8], privateKey: [UInt8], isTest: Bool = false) -> JavaScriptWallet? {
+    let result = walletClass.construct(withArguments: [publicKey.toHex(), privateKey.toHex(), isTest])!
+    return result.toWallet()
+  }
+
   /// Initialize a new `Wallet` with a mnemonic and a derivation path.
   ///
   /// - Parameters:

--- a/XpringKit/Wallet.swift
+++ b/XpringKit/Wallet.swift
@@ -62,6 +62,24 @@ public class Wallet {
     self.init(javaScriptWallet: javaScriptWallet)
   }
 
+  /// Initialize a new `Wallet` with a set of keys.
+  ///
+  /// - Parameters:
+  ///   - publicKey: Bytes representing a public key.
+  ///   - privateKey: Bytes representing a private key.
+  ///   - isTest: Whether the address is for use on a test network.
+  /// - Returns: A new wallet if inputs were valid, otherwise nil.
+  public convenience init?(publicKey: [UInt8], privateKey: [UInt8], isTest: Bool = false) {
+    guard let javaScriptWallet = Wallet.javaScriptWalletFactory.wallet(
+      publicKey: publicKey,
+      privateKey: privateKey,
+      isTest: isTest
+    ) else {
+      return nil
+    }
+    self.init(javaScriptWallet: javaScriptWallet)
+  }
+
   /// Initialize a new `Wallet` backed by the given JavaScript based wallet.
   internal init(javaScriptWallet: JavaScriptWallet) {
     self.javaScriptWallet = javaScriptWallet


### PR DESCRIPTION
## High Level Overview of Change

Add an initializer that lets users create a wallet from public and private keys.

Analog in Java: https://github.com/xpring-eng/xpring4j/pull/182

### Context of Change

Create an initializer and unit tests that work on raw public / private keys.

Wire tests for this method as well. Note that the underlying JS implementation doesn't do any validity checking on the input keys so there's actually no way to make this method fail. 

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Can construct wallets from public / private keys. This is a useful feature to have, but also lets us create a `FakeWallet` class for testing.

## Test Plan

New unit tests introduced for CI.