### PR TITLE
Remove Xpring-Common-Protocol-Buffers Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,6 @@
 	path = xpring-common-js
 	url = https://github.com/xpring-eng/xpring-common-js
 	branch = master
-[submodule "xpring-common-protocol-buffers"]
-	path = xpring-common-protocol-buffers
-	url = https://github.com/xpring-eng/xpring-common-protocol-buffers
-	branch = master
 [submodule "hermes-ilp"]
 	path = hermes-ilp
 	url = https://github.com/xpring-eng/hermes-ilp


### PR DESCRIPTION
## High Level Overview of Change

Remove this submodule. It is dead code. 

### Context of Change

We removed code depending on this submodule. No reason to keep the submodule reference around. 

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI 