### PR TITLE
Fix semantics of methods for current open ledger and last validated ledger

### DIFF
--- a/Tests/Fakes/FakeXRPClient.swift
+++ b/Tests/Fakes/FakeXRPClient.swift
@@ -1,4 +1,4 @@
-import XpringKit
+@testable import XpringKit
 
 /// A  fake XRPClient which returns the given iVars as results from XRPClientDecorator calls.
 ///
@@ -55,7 +55,7 @@ extension FakeXRPClient: XRPClientDecorator {
     return try returnOrThrow(result: sendValue)
   }
 
-  public func getLatestValidatedLedgerSequence() throws -> UInt32 {
+  public func getLatestValidatedLedgerSequence(address: Address) throws -> UInt32 {
     return try returnOrThrow(result: latestValidatedLedgerValue)
   }
 

--- a/Tests/ReliableSubmissionXpringClientTest.swift
+++ b/Tests/ReliableSubmissionXpringClientTest.swift
@@ -61,7 +61,10 @@ final class ReliableSubmissionClientTest: XCTestCase {
   func testGetLatestValidatedLedgerSequence() {
     // GIVEN a `ReliableSubmissionClient` decorating a FakeXRPClient WHEN the latest ledger sequence is retrieved
     // THEN the result is returned unaltered.
-    XCTAssertEqual(try? reliableSubmissionClient.getLatestValidatedLedgerSequence(), defaultLatestValidatedLedgerValue)
+    XCTAssertEqual(
+      try? reliableSubmissionClient.getLatestValidatedLedgerSequence(address: .testAddress),
+      defaultLatestValidatedLedgerValue
+    )
   }
 
   func testGetRawTransactionStatus() {

--- a/XpringKit/XRP/XRPClientDecorator.swift
+++ b/XpringKit/XRP/XRPClientDecorator.swift
@@ -1,5 +1,5 @@
 /// A decorator for a XRPClient.
-public protocol XRPClientDecorator {
+internal protocol XRPClientDecorator {
   /// Get the balance for the given address.
   ///
   /// - Parameter address: The X-Address to retrieve the balance for.
@@ -29,9 +29,14 @@ public protocol XRPClientDecorator {
 
   /// Retrieve the latest validated ledger sequence on the XRP Ledger.
   ///
+  /// - Note: This call will throw if the given account does not exist on the ledger at the current time. It is the
+  /// *caller's responsibility* to ensure this invariant is met.
+  /// TODO(keefertaylor): Replace this brittle logic when rippled supports a `ledger` RPC via gRPC.
+  ///
+  /// - Parameter address: An address that exists at the current time.
   /// - Throws: An error if there was a problem communicating with the XRP Ledger.
   /// - Returns: The index of the latest validated ledger.
-  func getLatestValidatedLedgerSequence() throws -> UInt32
+  func getLatestValidatedLedgerSequence(address: Address) throws -> UInt32
 
   /// Retrieve the raw transaction status for the given transaction hash.
   ///


### PR DESCRIPTION
## High Level Overview of Change

The current implementation of `getLatestValidatedLedgerSequence` returns the latest *open* ledger sequence. 

Fix this method's name and re-implement `getLatestValidatedLedgerSequence`.

### Context of Change

There are a number of assumptions required to get `getLatestValidatedLedgerSequence` working. Namely, an address that is guaranteed to exist needs to be provided. 

I've worked with @carlhua  and @cjcobb23  on the rippled team and we are convinced that this implementation will never fail to return the latest validated ledger sequence when called from our reliable submission logic. 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Reliable submission bug is fixed. 

## Test Plan

CI