### PR TITLE
Adds `validated` and `ledgerIndex` fields to `XRPTransaction`

### DIFF
--- a/Tests/ProtocolBufferConversionTests.swift
+++ b/Tests/ProtocolBufferConversionTests.swift
@@ -462,6 +462,9 @@ final class ProtocolBufferConversionTests: XCTestCase {
     let memoData = Data([1, 2, 3])
     let memoFormat = Data([4, 5, 6])
     let memoType = Data([7, 8, 9])
+    let validated = true
+    let ledgerIndex = UInt32(1_000)
+
     let memoProto = Org_Xrpl_Rpc_V1_Memo.with {
       $0.memoData = Org_Xrpl_Rpc_V1_MemoData.with {
         $0.value = memoData
@@ -550,6 +553,8 @@ final class ProtocolBufferConversionTests: XCTestCase {
           }
         }
       }
+      $0.validated = validated
+      $0.ledgerIndex = ledgerIndex
     }
     // WHEN the protocol buffer is converted to a native Swift type.
     let transaction = XRPTransaction(getTransactionResponse: getTransactionResponseProto)
@@ -569,6 +574,8 @@ final class ProtocolBufferConversionTests: XCTestCase {
     XCTAssertEqual(transaction?.sourceTag, sourceTag)
     XCTAssertEqual(transaction?.timestamp, .expectedTimestamp)
     XCTAssertEqual(transaction?.deliveredAmount, String(deliveredAmount))
+    XCTAssertEqual(transaction?.validated, validated)
+    XCTAssertEqual(transaction?.ledgerIndex, ledgerIndex)
   }
 
   func testConvertPaymentTransactionOnlyMandatoryCommonFieldsSet() {

--- a/XpringKit/XRP/model/Org_Xrpl_Rpc_V1_Transaction+XRPTransaction.swift
+++ b/XpringKit/XRP/model/Org_Xrpl_Rpc_V1_Transaction+XRPTransaction.swift
@@ -65,5 +65,8 @@ internal extension XRPTransaction {
     } else {
       self.deliveredAmount = nil
     }
+    
+    self.validated = getTransactionResponse.validated
+    self.ledgerIndex = getTransactionResponse.ledgerIndex
   }
 }

--- a/XpringKit/XRP/model/Org_Xrpl_Rpc_V1_Transaction+XRPTransaction.swift
+++ b/XpringKit/XRP/model/Org_Xrpl_Rpc_V1_Transaction+XRPTransaction.swift
@@ -65,7 +65,7 @@ internal extension XRPTransaction {
     } else {
       self.deliveredAmount = nil
     }
-    
+
     self.validated = getTransactionResponse.validated
     self.ledgerIndex = getTransactionResponse.ledgerIndex
   }

--- a/XpringKit/XRP/model/XRPTransaction.swift
+++ b/XpringKit/XRP/model/XRPTransaction.swift
@@ -62,6 +62,13 @@ public struct XRPTransaction: Equatable {
   /// - SeeAlso: "https://xrpl.org/transaction-metadata.html#delivered_amount"
   public let deliveredAmount: String?
 
+  /// A boolean indicating whether this transaction was found on a validated ledger, and not an open or closed ledger.
+  /// - SeeAlso: "https://xrpl.org/ledgers.html#open-closed-and-validated-ledgers"
+  public let validated: Bool
+  
+  /// The index of the ledger on which this transaction was found.
+  public let ledgerIndex: UInt32
+  
   /// Transaction specific fields, only one of the following will be set.
 
   /// An XRPPayment object representing the additional fields present in a PAYMENT transaction.

--- a/XpringKit/XRP/model/XRPTransaction.swift
+++ b/XpringKit/XRP/model/XRPTransaction.swift
@@ -65,10 +65,10 @@ public struct XRPTransaction: Equatable {
   /// A boolean indicating whether this transaction was found on a validated ledger, and not an open or closed ledger.
   /// - SeeAlso: "https://xrpl.org/ledgers.html#open-closed-and-validated-ledgers"
   public let validated: Bool
-  
+
   /// The index of the ledger on which this transaction was found.
   public let ledgerIndex: UInt32
-  
+
   /// Transaction specific fields, only one of the following will be set.
 
   /// An XRPPayment object representing the additional fields present in a PAYMENT transaction.


### PR DESCRIPTION
## High Level Overview of Change
This PR adds the `validated` and `ledgerIndex` fields to the `XRPTransaction` object. 
These fields come from a `GetTransactionResponse` protobuf object, which is returned by a call to `getTransaction`. 

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
This change is made in preparation for implementing a `getTransaction` method in the SDKs. The original implementation of the `XRPTransaction` class in the SDK only included the fields present in the `Transaction` protocol buffer object (which is wrapped by a `GetTransactionResponse` also containing other metadata about the transaction's outcome.) Certain of these other metadata fields have been added as-needed to the `XRPTransaction` object, and this PR takes care of the remaining fields available in `GetTransactionResponse`.

Our current approach is to combine the distinct `GetTransactionResponse` and `Transaction` protocol buffer objects into one type (`XRPTransaction`) since the metadata about the transaction's outcome is of equal importance to the specific transaction data, and while the type distinction makes sense in the context of authoring rippled, it would add unnecessary complexity in the SDK. 

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] New feature (non-breaking change which adds functionality)

## Before / After
Two additional fields available on an `XRPTransaction` object.
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
Added new test values to fake protobuf objects for conversion tests.
CI passes.
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->


## Future Tasks
<!--
For future tasks related to PR.
-->