### PR TITLE
Adds X-Addresses to `XRPTransaction` and `XRPPayment` model objects

### DIFF
--- a/Tests/DefaultXRPClientTest.swift
+++ b/Tests/DefaultXRPClientTest.swift
@@ -11,7 +11,7 @@ final class DefaultXRPClientTest: XCTestCase {
   // MARK: - Balance
   func testGetBalanceWithSuccess() {
     // GIVEN an XRPClient which will successfully return a balance from a mocked network call.
-    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient, xrplNetwork: XRPLNetwork.test)
 
     // WHEN the balance is requested.
     guard let balance = try? xrpClient.getBalance(for: .testAddress) else {
@@ -29,7 +29,7 @@ final class DefaultXRPClientTest: XCTestCase {
       XCTFail("Failed to decode X-Address.")
       return
     }
-    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient, xrplNetwork: XRPLNetwork.test)
 
     // WHEN the balance is requested THEN an error is thrown.
     XCTAssertThrowsError(
@@ -55,7 +55,7 @@ final class DefaultXRPClientTest: XCTestCase {
       transactionStatusResult: .success(.testGetTransactionResponse),
       transactionHistoryResult: .success(.testTransactionHistoryResponse)
     )
-    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+    let xrpClient = DefaultXRPClient(networkClient: networkClient, xrplNetwork: XRPLNetwork.test)
 
     // WHEN the balance is requested THEN the error is thrown.
     XCTAssertThrowsError(try xrpClient.getBalance(for: .testAddress), "Exception not thrown") { error in
@@ -71,7 +71,7 @@ final class DefaultXRPClientTest: XCTestCase {
   // MARK: - Send
   func testSendWithSuccess() {
     // GIVEN an XRPClient client which will successfully return a balance from a mocked network call.
-    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient, xrplNetwork: XRPLNetwork.test)
 
     // WHEN XRP is sent.
     guard
@@ -95,7 +95,7 @@ final class DefaultXRPClientTest: XCTestCase {
       XCTFail("Failed to decode X - Address.")
       return
     }
-    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient, xrplNetwork: XRPLNetwork.test)
 
     // WHEN XRP is sent to a classic address THEN an error is thrown.
     XCTAssertThrowsError(
@@ -109,7 +109,7 @@ final class DefaultXRPClientTest: XCTestCase {
 
   func testSendWithInvalidAddress() {
     // GIVEN an XRPClient client and an invalid destination address.
-    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient, xrplNetwork: XRPLNetwork.test)
     let destinationAddress = "xrp"
 
     // WHEN XRP is sent to an invalid address THEN an error is thrown.
@@ -131,7 +131,7 @@ final class DefaultXRPClientTest: XCTestCase {
       transactionStatusResult: .success(.testGetTransactionResponse),
       transactionHistoryResult: .success(.testTransactionHistoryResponse)
     )
-    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+    let xrpClient = DefaultXRPClient(networkClient: networkClient, xrplNetwork: XRPLNetwork.test)
 
     // WHEN a send is attempted then an error is thrown.
     XCTAssertThrowsError(
@@ -152,7 +152,7 @@ final class DefaultXRPClientTest: XCTestCase {
       transactionStatusResult: .success(.testGetTransactionResponse),
       transactionHistoryResult: .success(.testTransactionHistoryResponse)
     )
-    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+    let xrpClient = DefaultXRPClient(networkClient: networkClient, xrplNetwork: XRPLNetwork.test)
 
     // WHEN a send is attempted then an error is thrown.
     XCTAssertThrowsError(
@@ -173,7 +173,7 @@ final class DefaultXRPClientTest: XCTestCase {
       transactionStatusResult: .success(.testGetTransactionResponse),
       transactionHistoryResult: .success(.testTransactionHistoryResponse)
     )
-    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+    let xrpClient = DefaultXRPClient(networkClient: networkClient, xrplNetwork: XRPLNetwork.test)
 
     // WHEN a send is attempted then an error is thrown.
     XCTAssertThrowsError(
@@ -202,7 +202,7 @@ final class DefaultXRPClientTest: XCTestCase {
         transactionStatusResult: .success(transactionStatusResponse),
         transactionHistoryResult: .success(.testTransactionHistoryResponse)
       )
-      let xrpClient = DefaultXRPClient(networkClient: networkClient)
+      let xrpClient = DefaultXRPClient(networkClient: networkClient, xrplNetwork: XRPLNetwork.test)
 
       // WHEN the payment status is retrieved.
       let paymentStatus = try? xrpClient.paymentStatus(for: .testTransactionHash)
@@ -225,7 +225,7 @@ final class DefaultXRPClientTest: XCTestCase {
       transactionStatusResult: .success(transactionStatusResponse),
       transactionHistoryResult: .success(.testTransactionHistoryResponse)
     )
-    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+    let xrpClient = DefaultXRPClient(networkClient: networkClient, xrplNetwork: XRPLNetwork.test)
 
     // WHEN the payment status is retrieved.
     let paymentStatus = try? xrpClient.paymentStatus(for: .testTransactionHash)
@@ -249,7 +249,7 @@ final class DefaultXRPClientTest: XCTestCase {
         transactionStatusResult: .success(transactionStatusResponse),
         transactionHistoryResult: .success(.testTransactionHistoryResponse)
       )
-      let xrpClient = DefaultXRPClient(networkClient: networkClient)
+      let xrpClient = DefaultXRPClient(networkClient: networkClient, xrplNetwork: XRPLNetwork.test)
 
       // WHEN the payment status is retrieved.
       let paymentStatus = try? xrpClient.paymentStatus(for: .testTransactionHash)
@@ -272,7 +272,7 @@ final class DefaultXRPClientTest: XCTestCase {
       transactionStatusResult: .success(transactionStatusResponse),
       transactionHistoryResult: .success(.testTransactionHistoryResponse)
     )
-    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+    let xrpClient = DefaultXRPClient(networkClient: networkClient, xrplNetwork: XRPLNetwork.test)
 
     // WHEN the payment status is retrieved.
     let paymentStatus = try? xrpClient.paymentStatus(for: .testTransactionHash)
@@ -290,7 +290,7 @@ final class DefaultXRPClientTest: XCTestCase {
       transactionStatusResult: .failure(XpringKitTestError.mockFailure),
       transactionHistoryResult: .success(.testTransactionHistoryResponse)
     )
-    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+    let xrpClient = DefaultXRPClient(networkClient: networkClient, xrplNetwork: XRPLNetwork.test)
 
     // WHEN the payment status is retrieved THEN an error is thrown.
     XCTAssertThrowsError(try xrpClient.paymentStatus(for: .testTransactionHash))
@@ -308,7 +308,7 @@ final class DefaultXRPClientTest: XCTestCase {
       transactionStatusResult: .success(getTransactionResponse),
       transactionHistoryResult: .success(.testTransactionHistoryResponse)
     )
-    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+    let xrpClient = DefaultXRPClient(networkClient: networkClient, xrplNetwork: XRPLNetwork.test)
 
     // WHEN the payment status is retrieved.
     let paymentStatus = try? xrpClient.paymentStatus(for: .testTransactionHash)
@@ -334,7 +334,7 @@ final class DefaultXRPClientTest: XCTestCase {
       transactionStatusResult: .success(getTransactionResponse),
       transactionHistoryResult: .success(.testTransactionHistoryResponse)
     )
-    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+    let xrpClient = DefaultXRPClient(networkClient: networkClient, xrplNetwork: XRPLNetwork.test)
 
     // WHEN the payment status is retrieved.
     let paymentStatus = try? xrpClient.paymentStatus(for: .testTransactionHash)
@@ -347,7 +347,7 @@ final class DefaultXRPClientTest: XCTestCase {
 
   func testAccountExistsWithSuccess() {
     // GIVEN an XRPClient which will successfully return a balance from a mocked network call.
-    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient, xrplNetwork: XRPLNetwork.test)
 
     // WHEN the existence of the account is checked.
     guard let exists = try? xrpClient.accountExists(for: .testAddress) else {
@@ -365,7 +365,7 @@ final class DefaultXRPClientTest: XCTestCase {
       XCTFail("Failed to decode X-Address.")
       return
     }
-    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient, xrplNetwork: XRPLNetwork.test)
 
     // WHEN the account's existence is checked THEN an error is thrown.
     XCTAssertThrowsError(
@@ -401,7 +401,7 @@ final class DefaultXRPClientTest: XCTestCase {
       transactionStatusResult: .success(.testGetTransactionResponse),
       transactionHistoryResult: .success(.testTransactionHistoryResponse)
     )
-    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+    let xrpClient = DefaultXRPClient(networkClient: networkClient, xrplNetwork: XRPLNetwork.test)
 
     // WHEN the existence of the account is checked
     guard let exists = try? xrpClient.accountExists(for: .testAddress) else {
@@ -433,7 +433,7 @@ final class DefaultXRPClientTest: XCTestCase {
       transactionStatusResult: .success(.testGetTransactionResponse),
       transactionHistoryResult: .success(.testTransactionHistoryResponse)
     )
-    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+    let xrpClient = DefaultXRPClient(networkClient: networkClient, xrplNetwork: XRPLNetwork.test)
 
     // WHEN the account's existence is checked THEN the error is re-thrown.
     XCTAssertThrowsError(
@@ -453,7 +453,7 @@ final class DefaultXRPClientTest: XCTestCase {
 
   func testPaymentHistoryWithSuccess() {
     // GIVEN an XRPClient client which will successfully return a transactionHistory mocked network call.
-    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient, xrplNetwork: XRPLNetwork.test)
     let expectedTransactions = Org_Xrpl_Rpc_V1_GetAccountTransactionHistoryResponse
       .testTransactionHistoryResponse
       .transactions
@@ -477,7 +477,7 @@ final class DefaultXRPClientTest: XCTestCase {
       XCTFail("Failed to decode X-Address.")
       return
     }
-    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient)
+    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient, xrplNetwork: XRPLNetwork.test)
 
     // WHEN the payment history is requested THEN an error is thrown.
     XCTAssertThrowsError(
@@ -503,7 +503,7 @@ final class DefaultXRPClientTest: XCTestCase {
       transactionStatusResult: .success(.testGetTransactionResponse),
       transactionHistoryResult: .failure(XpringKitTestError.mockFailure)
     )
-    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+    let xrpClient = DefaultXRPClient(networkClient: networkClient, xrplNetwork: XRPLNetwork.test)
 
     // WHEN the payment history is requested THEN an error is thrown.
     XCTAssertThrowsError(try xrpClient.paymentHistory(for: .testAddress), "Exception not thrown") { error in
@@ -539,7 +539,7 @@ final class DefaultXRPClientTest: XCTestCase {
       transactionStatusResult: .success(.testGetTransactionResponse),
       transactionHistoryResult: .success(transactionHistory)
     )
-    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+    let xrpClient = DefaultXRPClient(networkClient: networkClient, xrplNetwork: XRPLNetwork.test)
 
     // WHEN the transactionHistory is requested.
     guard let transactions = try? xrpClient.paymentHistory(for: .testAddress) else {
@@ -575,7 +575,7 @@ final class DefaultXRPClientTest: XCTestCase {
       transactionStatusResult: .success(.testGetTransactionResponse),
       transactionHistoryResult: .success(transactionHistory)
     )
-    let xrpClient = DefaultXRPClient(networkClient: networkClient)
+    let xrpClient = DefaultXRPClient(networkClient: networkClient, xrplNetwork: XRPLNetwork.test)
 
     // WHEN the transactionHistory is requested THEN an error is thrown.
     XCTAssertThrowsError(try xrpClient.paymentHistory(for: .testAddress), "Exception not thrown") { error in

--- a/Tests/DefaultXRPClientTest.swift
+++ b/Tests/DefaultXRPClientTest.swift
@@ -11,7 +11,10 @@ final class DefaultXRPClientTest: XCTestCase {
   // MARK: - Balance
   func testGetBalanceWithSuccess() {
     // GIVEN an XRPClient which will successfully return a balance from a mocked network call.
-    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient, xrplNetwork: XRPLNetwork.test)
+    let xrpClient = DefaultXRPClient(
+      networkClient: FakeNetworkClient.successfulFakeNetworkClient,
+      xrplNetwork: XRPLNetwork.test
+    )
 
     // WHEN the balance is requested.
     guard let balance = try? xrpClient.getBalance(for: .testAddress) else {
@@ -29,7 +32,10 @@ final class DefaultXRPClientTest: XCTestCase {
       XCTFail("Failed to decode X-Address.")
       return
     }
-    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient, xrplNetwork: XRPLNetwork.test)
+    let xrpClient = DefaultXRPClient(
+      networkClient: FakeNetworkClient.successfulFakeNetworkClient,
+      xrplNetwork: XRPLNetwork.test
+    )
 
     // WHEN the balance is requested THEN an error is thrown.
     XCTAssertThrowsError(
@@ -71,7 +77,10 @@ final class DefaultXRPClientTest: XCTestCase {
   // MARK: - Send
   func testSendWithSuccess() {
     // GIVEN an XRPClient client which will successfully return a balance from a mocked network call.
-    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient, xrplNetwork: XRPLNetwork.test)
+    let xrpClient = DefaultXRPClient(
+      networkClient: FakeNetworkClient.successfulFakeNetworkClient,
+      xrplNetwork: XRPLNetwork.test
+    )
 
     // WHEN XRP is sent.
     guard
@@ -95,7 +104,10 @@ final class DefaultXRPClientTest: XCTestCase {
       XCTFail("Failed to decode X - Address.")
       return
     }
-    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient, xrplNetwork: XRPLNetwork.test)
+    let xrpClient = DefaultXRPClient(
+      networkClient: FakeNetworkClient.successfulFakeNetworkClient,
+      xrplNetwork: XRPLNetwork.test
+    )
 
     // WHEN XRP is sent to a classic address THEN an error is thrown.
     XCTAssertThrowsError(
@@ -109,7 +121,10 @@ final class DefaultXRPClientTest: XCTestCase {
 
   func testSendWithInvalidAddress() {
     // GIVEN an XRPClient client and an invalid destination address.
-    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient, xrplNetwork: XRPLNetwork.test)
+    let xrpClient = DefaultXRPClient(
+      networkClient: FakeNetworkClient.successfulFakeNetworkClient,
+      xrplNetwork: XRPLNetwork.test
+    )
     let destinationAddress = "xrp"
 
     // WHEN XRP is sent to an invalid address THEN an error is thrown.
@@ -347,7 +362,10 @@ final class DefaultXRPClientTest: XCTestCase {
 
   func testAccountExistsWithSuccess() {
     // GIVEN an XRPClient which will successfully return a balance from a mocked network call.
-    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient, xrplNetwork: XRPLNetwork.test)
+    let xrpClient = DefaultXRPClient(
+      networkClient: FakeNetworkClient.successfulFakeNetworkClient,
+      xrplNetwork: XRPLNetwork.test
+    )
 
     // WHEN the existence of the account is checked.
     guard let exists = try? xrpClient.accountExists(for: .testAddress) else {
@@ -365,7 +383,10 @@ final class DefaultXRPClientTest: XCTestCase {
       XCTFail("Failed to decode X-Address.")
       return
     }
-    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient, xrplNetwork: XRPLNetwork.test)
+    let xrpClient = DefaultXRPClient(
+      networkClient: FakeNetworkClient.successfulFakeNetworkClient,
+      xrplNetwork: XRPLNetwork.test
+    )
 
     // WHEN the account's existence is checked THEN an error is thrown.
     XCTAssertThrowsError(
@@ -453,7 +474,10 @@ final class DefaultXRPClientTest: XCTestCase {
 
   func testPaymentHistoryWithSuccess() {
     // GIVEN an XRPClient client which will successfully return a transactionHistory mocked network call.
-    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient, xrplNetwork: XRPLNetwork.test)
+    let xrpClient = DefaultXRPClient(
+      networkClient: FakeNetworkClient.successfulFakeNetworkClient,
+      xrplNetwork: XRPLNetwork.test
+    )
     let expectedTransactions = Org_Xrpl_Rpc_V1_GetAccountTransactionHistoryResponse
       .testTransactionHistoryResponse
       .transactions
@@ -477,7 +501,10 @@ final class DefaultXRPClientTest: XCTestCase {
       XCTFail("Failed to decode X-Address.")
       return
     }
-    let xrpClient = DefaultXRPClient(networkClient: FakeNetworkClient.successfulFakeNetworkClient, xrplNetwork: XRPLNetwork.test)
+    let xrpClient = DefaultXRPClient(
+      networkClient: FakeNetworkClient.successfulFakeNetworkClient,
+      xrplNetwork: XRPLNetwork.test
+    )
 
     // WHEN the payment history is requested THEN an error is thrown.
     XCTAssertThrowsError(

--- a/Tests/Fakes/FakeXRPClient.swift
+++ b/Tests/Fakes/FakeXRPClient.swift
@@ -5,6 +5,7 @@
 /// - Note: Since this class is passed by reference and the instance variables are mutable, outputs of this class
 ///         can be changed after it is instantiated.
 public class FakeXRPClient: XRPClientProtocol {
+  public let network: XRPLNetwork
   public let xrplNetwork: XRPLNetwork
 
   public let networkClient = FakeNetworkClient.successfulFakeNetworkClient
@@ -19,6 +20,7 @@ public class FakeXRPClient: XRPClientProtocol {
 
   public init(
     network: XRPLNetwork = .test,
+    xrplNetwork: XRPLNetwork = .test,
     getBalanceValue: Result<UInt64, XRPLedgerError>,
     paymentStatusValue: Result<TransactionStatus, XRPLedgerError>,
     sendValue: Result<TransactionHash, XRPLedgerError>,
@@ -27,7 +29,8 @@ public class FakeXRPClient: XRPClientProtocol {
     paymentHistoryValue: Result<[XRPTransaction], XRPLedgerError>,
     accountExistsValue: Result<Bool, XRPLedgerError>
   ) {
-    self.xrplNetwork = network
+    self.network = xrplNetwork
+    self.xrplNetwork = xrplNetwork
     self.getBalanceValue = getBalanceValue
     self.paymentStatusValue = paymentStatusValue
     self.sendValue = sendValue

--- a/Tests/Fakes/FakeXRPClient.swift
+++ b/Tests/Fakes/FakeXRPClient.swift
@@ -5,7 +5,7 @@
 /// - Note: Since this class is passed by reference and the instance variables are mutable, outputs of this class
 ///         can be changed after it is instantiated.
 public class FakeXRPClient: XRPClientProtocol {
-  public let network: XRPLNetwork
+  public let xrplNetwork: XRPLNetwork
 
   public let networkClient = FakeNetworkClient.successfulFakeNetworkClient
 
@@ -27,7 +27,7 @@ public class FakeXRPClient: XRPClientProtocol {
     paymentHistoryValue: Result<[XRPTransaction], XRPLedgerError>,
     accountExistsValue: Result<Bool, XRPLedgerError>
   ) {
-    self.network = network
+    self.xrplNetwork = network
     self.getBalanceValue = getBalanceValue
     self.paymentStatusValue = paymentStatusValue
     self.sendValue = sendValue

--- a/Tests/ProtocolBufferConversionTests.swift
+++ b/Tests/ProtocolBufferConversionTests.swift
@@ -297,11 +297,16 @@ final class ProtocolBufferConversionTests: XCTestCase {
 
     // WHEN the protocol buffer is converted to a native Swift type.
     let payment = XRPPayment(payment: paymentProto)
-
+    let expectedXAddress = Utils.encode(
+      classicAddress: payment!.destination,
+      tag: payment?.destinationTag,
+      isTest: false
+    )
     // THEN the result is as expected.
     XCTAssertEqual(payment?.amount, XRPCurrencyAmount(currencyAmount: paymentProto.amount.value))
     XCTAssertEqual(payment?.destination, paymentProto.destination.value.address)
     XCTAssertEqual(payment?.destinationTag, paymentProto.destinationTag.value)
+    XCTAssertEqual(payment?.destinationXAddress, expectedXAddress)
     XCTAssertEqual(payment?.deliverMin, XRPCurrencyAmount(currencyAmount: paymentProto.deliverMin.value))
     XCTAssertEqual(payment?.invoiceID, paymentProto.invoiceID.value)
     XCTAssertEqual(payment?.paths, paymentProto.paths.map { XRPPath(path: $0) })
@@ -324,12 +329,18 @@ final class ProtocolBufferConversionTests: XCTestCase {
     }
 
     // WHEN the protocol buffer is converted to a native Swift type.
-    let payment = XRPPayment(payment: paymentProto)
-
+    let payment = XRPPayment(payment: paymentProto, xrplNetwork: XRPLNetwork.test)
+    let expectedXAddress = Utils.encode(
+      classicAddress: payment!.destination,
+      tag: payment?.destinationTag,
+      isTest: true
+    )
+    
     // THEN the result is as expected.
     XCTAssertEqual(payment?.amount, XRPCurrencyAmount(currencyAmount: paymentProto.amount.value))
     XCTAssertEqual(payment?.destination, paymentProto.destination.value.address)
     XCTAssertNil(payment?.destinationTag)
+    XCTAssertEqual(payment?.destinationXAddress, expectedXAddress)
     XCTAssertNil(payment?.deliverMin)
     XCTAssertNil(payment?.invoiceID)
     XCTAssertNil(payment?.paths)
@@ -558,10 +569,16 @@ final class ProtocolBufferConversionTests: XCTestCase {
     }
     // WHEN the protocol buffer is converted to a native Swift type.
     let transaction = XRPTransaction(getTransactionResponse: getTransactionResponseProto)
-
+    let expectedXAddress = Utils.encode(
+      classicAddress: transaction!.account,
+      tag: nil,
+      isTest: false
+    )
+    
     // THEN all fields are present and converted correctly.
     XCTAssertEqual(transaction?.hash, [UInt8](hash).toHex())
     XCTAssertEqual(transaction?.account, account)
+    XCTAssertEqual(transaction?.accountXAddress, expectedXAddress)
     XCTAssertEqual(transaction?.fee, fee)
     XCTAssertEqual(transaction?.sequence, sequence)
     XCTAssertEqual(transaction?.signingPublicKey, signingPublicKey)
@@ -625,11 +642,21 @@ final class ProtocolBufferConversionTests: XCTestCase {
       $0.hash = hash
     }
     // WHEN the protocol buffer is converted to a native Swift type.
-    let transaction = XRPTransaction(getTransactionResponse: getTransactionResponseProto)
-
+    let transaction = XRPTransaction(
+      getTransactionResponse: getTransactionResponseProto,
+      xrplNetwork: XRPLNetwork.test
+    )
+    
+    let expectedXAddress = Utils.encode(
+      classicAddress: transaction!.account,
+      tag: nil,
+      isTest: true
+    )
+    
     // THEN all fields are present and converted correctly.
     XCTAssertEqual(transaction?.hash, [UInt8](hash).toHex())
     XCTAssertEqual(transaction?.account, account)
+    XCTAssertEqual(transaction?.accountXAddress, expectedXAddress)
     XCTAssertEqual(transaction?.fee, fee)
     XCTAssertEqual(transaction?.sequence, sequence)
     XCTAssertEqual(transaction?.signingPublicKey, signingPublicKey)

--- a/Tests/ReliableSubmissionXpringClientTest.swift
+++ b/Tests/ReliableSubmissionXpringClientTest.swift
@@ -40,7 +40,10 @@ final class ReliableSubmissionClientTest: XCTestCase {
       accountExistsValue: .success(defaultAccountExistsValue)
     )
 
-    reliableSubmissionClient = ReliableSubmissionXRPClient(decoratedClient: fakeXRPClient)
+    reliableSubmissionClient = ReliableSubmissionXRPClient(
+      decoratedClient: fakeXRPClient,
+      xrplNetwork: fakeXRPClient.xrplNetwork
+    )
   }
 
   func testGetBalance() {

--- a/XpringKit/XRP/DefaultXRPClient.swift
+++ b/XpringKit/XRP/DefaultXRPClient.swift
@@ -301,7 +301,11 @@ extension DefaultXRPClient: XRPClientDecorator {
       switch transaction.transactionData {
       case .payment:
         // If a payment can't be converted throw an error to prevent returning incomplete data.
-        guard let xrpTransaction = XRPTransaction(getTransactionResponse: transactionResponse, xrplNetwork: self.xrplNetwork) else {
+        guard let xrpTransaction = XRPTransaction(
+          getTransactionResponse: transactionResponse,
+          xrplNetwork: self.xrplNetwork
+        )
+        else {
           throw XRPLedgerError.unknown(
             "Could not convert payment transaction: \(transaction). " +
             "Please file a bug at https://github.com/xpring-eng/xpringkit"

--- a/XpringKit/XRP/DefaultXRPClient.swift
+++ b/XpringKit/XRP/DefaultXRPClient.swift
@@ -7,11 +7,11 @@ public class DefaultXRPClient {
   private let maxLedgerVersionOffset: UInt32 = 10
 
   /// The XRPL network this XRPClient is connecting to.
-  private let xrplNetwork: XRPLNetwork
-  
+  internal let xrplNetwork: XRPLNetwork
+
   /// A network client that will make and receive requests.
   private let networkClient: NetworkClient
-  
+
   /// Initialize a new XRPClient.
   ///
   /// - Parameter grpcURL: A url for a remote gRPC service which will handle network requests.

--- a/XpringKit/XRP/DefaultXRPClient.swift
+++ b/XpringKit/XRP/DefaultXRPClient.swift
@@ -301,7 +301,7 @@ extension DefaultXRPClient: XRPClientDecorator {
       switch transaction.transactionData {
       case .payment:
         // If a payment can't be converted throw an error to prevent returning incomplete data.
-        guard let xrpTransaction = XRPTransaction(getTransactionResponse: transactionResponse) else {
+        guard let xrpTransaction = XRPTransaction(getTransactionResponse: transactionResponse, xrplNetwork: self.xrplNetwork) else {
           throw XRPLedgerError.unknown(
             "Could not convert payment transaction: \(transaction). " +
             "Please file a bug at https://github.com/xpring-eng/xpringkit"

--- a/XpringKit/XRP/DefaultXRPClient.swift
+++ b/XpringKit/XRP/DefaultXRPClient.swift
@@ -6,22 +6,26 @@ public class DefaultXRPClient {
   /// A margin to pad the current ledger sequence with when submitting transactions.
   private let maxLedgerVersionOffset: UInt32 = 10
 
+  /// The XRPL network this XRPClient is connecting to.
+  private let xrplNetwork: XRPLNetwork
+  
   /// A network client that will make and receive requests.
   private let networkClient: NetworkClient
-
+  
   /// Initialize a new XRPClient.
   ///
   /// - Parameter grpcURL: A url for a remote gRPC service which will handle network requests.
-  public convenience init(grpcURL: String) {
+  public convenience init(grpcURL: String, xrplNetwork: XRPLNetwork) {
     let networkClient = Org_Xrpl_Rpc_V1_XRPLedgerAPIServiceServiceClient(address: grpcURL, secure: false)
-    self.init(networkClient: networkClient)
+    self.init(networkClient: networkClient, xrplNetwork: xrplNetwork)
   }
 
   /// Initialize a new XRPClient.
   ///
   /// - Parameter networkClient: A network client which will make requests.
-  internal init(networkClient: NetworkClient) {
+  internal init(networkClient: NetworkClient, xrplNetwork: XRPLNetwork) {
     self.networkClient = networkClient
+    self.xrplNetwork = xrplNetwork
   }
 
   /// Retrieve the current fee to submit a transaction to the XRP Ledger.

--- a/XpringKit/XRP/ReliableSubmissionXRPClient.swift
+++ b/XpringKit/XRP/ReliableSubmissionXRPClient.swift
@@ -3,9 +3,11 @@ import Foundation
 /// A XRPClient which blocks on `send` calls until the transaction has reached a deterministic state.
 public class ReliableSubmissionXRPClient {
   private let decoratedClient: XRPClientDecorator
+  internal let xrplNetwork: XRPLNetwork
 
-  internal init(decoratedClient: XRPClientDecorator) {
+  internal init(decoratedClient: XRPClientDecorator, xrplNetwork: XRPLNetwork) {
     self.decoratedClient = decoratedClient
+    self.xrplNetwork = xrplNetwork
   }
 }
 

--- a/XpringKit/XRP/XRPClient.swift
+++ b/XpringKit/XRP/XRPClient.swift
@@ -11,7 +11,7 @@ public class XRPClient: XRPClientProtocol {
   ///   - grpcURL: A remote URL for a rippled gRPC service.
   ///   - network: The network this XRPClient is connecting to.
   public init(grpcURL: String, network: XRPLNetwork) {
-    let defaultClient = DefaultXRPClient(grpcURL: grpcURL)
+    let defaultClient = DefaultXRPClient(grpcURL: grpcURL, xrplNetwork: network)
     decoratedClient = ReliableSubmissionXRPClient(decoratedClient: defaultClient)
 
     self.network = network

--- a/XpringKit/XRP/XRPClient.swift
+++ b/XpringKit/XRP/XRPClient.swift
@@ -12,7 +12,7 @@ public class XRPClient: XRPClientProtocol {
   ///   - network: The network this XRPClient is connecting to.
   public init(grpcURL: String, network: XRPLNetwork) {
     let defaultClient = DefaultXRPClient(grpcURL: grpcURL, xrplNetwork: network)
-    decoratedClient = ReliableSubmissionXRPClient(decoratedClient: defaultClient)
+    decoratedClient = ReliableSubmissionXRPClient(decoratedClient: defaultClient, xrplNetwork: network)
 
     self.network = network
   }

--- a/XpringKit/XRP/XRPClientDecorator.swift
+++ b/XpringKit/XRP/XRPClientDecorator.swift
@@ -2,7 +2,7 @@
 internal protocol XRPClientDecorator {
   /// The XRPL network this XRPClient is connecting to.
   var xrplNetwork: XRPLNetwork { get }
-  
+
   /// Get the balance for the given address.
   ///
   /// - Parameter address: The X-Address to retrieve the balance for.

--- a/XpringKit/XRP/XRPClientDecorator.swift
+++ b/XpringKit/XRP/XRPClientDecorator.swift
@@ -1,5 +1,8 @@
 /// A decorator for a XRPClient.
 internal protocol XRPClientDecorator {
+  /// The XRPL network this XRPClient is connecting to.
+  var xrplNetwork: XRPLNetwork { get }
+  
   /// Get the balance for the given address.
   ///
   /// - Parameter address: The X-Address to retrieve the balance for.

--- a/XpringKit/XRP/model/Org_Xrpl_Rpc_V1_Payment+XRPPayment.swift
+++ b/XpringKit/XRP/model/Org_Xrpl_Rpc_V1_Payment+XRPPayment.swift
@@ -11,8 +11,9 @@ internal extension XRPPayment {
   /// - Parameters:
   ///     - payment: an Org_Xrpl_Rpc_V1_Payment (protobuf object) whose field values will be used to
   ///             construct an XRPPayment
+  ///     - xrplNetwork: The XRPL network from which this object was retrieved, defaults to XRPLNetwork.main (Mainnet).
   /// - Returns: an XRPPayment with its fields set via the analogous protobuf fields.
-  init?(payment: Org_Xrpl_Rpc_V1_Payment, xrplNetwork: XRPLNetwork) {
+  init?(payment: Org_Xrpl_Rpc_V1_Payment, xrplNetwork: XRPLNetwork = XRPLNetwork.main) {
     guard let amount = XRPCurrencyAmount(currencyAmount: payment.amount.value) else {
       return nil
     }
@@ -20,7 +21,7 @@ internal extension XRPPayment {
     self.destination = payment.destination.value.address
     self.destinationTag = payment.hasDestinationTag ? payment.destinationTag.value : nil
     self.destinationXAddress = Utils.encode(classicAddress: self.destination, tag: self.destinationTag, isTest: xrplNetwork == XRPLNetwork.test)!
-    
+
     // If the deliverMin field is set, it must be able to be transformed into a XRPCurrencyAmount.
     if payment.hasDeliverMin {
       if let deliverMin = XRPCurrencyAmount(currencyAmount: payment.deliverMin.value) {

--- a/XpringKit/XRP/model/Org_Xrpl_Rpc_V1_Payment+XRPPayment.swift
+++ b/XpringKit/XRP/model/Org_Xrpl_Rpc_V1_Payment+XRPPayment.swift
@@ -12,14 +12,15 @@ internal extension XRPPayment {
   ///     - payment: an Org_Xrpl_Rpc_V1_Payment (protobuf object) whose field values will be used to
   ///             construct an XRPPayment
   /// - Returns: an XRPPayment with its fields set via the analogous protobuf fields.
-  init?(payment: Org_Xrpl_Rpc_V1_Payment) {
+  init?(payment: Org_Xrpl_Rpc_V1_Payment, xrplNetwork: XRPLNetwork) {
     guard let amount = XRPCurrencyAmount(currencyAmount: payment.amount.value) else {
       return nil
     }
     self.amount = amount
     self.destination = payment.destination.value.address
     self.destinationTag = payment.hasDestinationTag ? payment.destinationTag.value : nil
-
+    self.destinationXAddress = Utils.encode(classicAddress: self.destination, tag: self.destinationTag, isTest: xrplNetwork == XRPLNetwork.test)!
+    
     // If the deliverMin field is set, it must be able to be transformed into a XRPCurrencyAmount.
     if payment.hasDeliverMin {
       if let deliverMin = XRPCurrencyAmount(currencyAmount: payment.deliverMin.value) {

--- a/XpringKit/XRP/model/Org_Xrpl_Rpc_V1_Payment+XRPPayment.swift
+++ b/XpringKit/XRP/model/Org_Xrpl_Rpc_V1_Payment+XRPPayment.swift
@@ -20,7 +20,11 @@ internal extension XRPPayment {
     self.amount = amount
     self.destination = payment.destination.value.address
     self.destinationTag = payment.hasDestinationTag ? payment.destinationTag.value : nil
-    self.destinationXAddress = Utils.encode(classicAddress: self.destination, tag: self.destinationTag, isTest: xrplNetwork == XRPLNetwork.test)!
+    self.destinationXAddress = Utils.encode(
+      classicAddress: self.destination,
+      tag: self.destinationTag,
+      isTest: xrplNetwork == XRPLNetwork.test
+    )
 
     // If the deliverMin field is set, it must be able to be transformed into a XRPCurrencyAmount.
     if payment.hasDeliverMin {

--- a/XpringKit/XRP/model/Org_Xrpl_Rpc_V1_Transaction+XRPTransaction.swift
+++ b/XpringKit/XRP/model/Org_Xrpl_Rpc_V1_Transaction+XRPTransaction.swift
@@ -19,9 +19,11 @@ internal extension XRPTransaction {
     let hashBytes = [UInt8](getTransactionResponse.hash)
     self.hash = hashBytes.toHex()
     self.account = transaction.account.value.address
-    self.accountXAddress = Utils.encode(classicAddress: self.account,
-                                        tag: nil,
-                                        isTest: xrplNetwork == XRPLNetwork.test)!
+    self.accountXAddress = Utils.encode(
+      classicAddress: self.account,
+      tag: nil,
+      isTest: xrplNetwork == XRPLNetwork.test
+    )
     self.fee = transaction.fee.drops
     self.sequence = transaction.sequence.value
     self.signingPublicKey = transaction.signingPublicKey.value

--- a/XpringKit/XRP/model/Org_Xrpl_Rpc_V1_Transaction+XRPTransaction.swift
+++ b/XpringKit/XRP/model/Org_Xrpl_Rpc_V1_Transaction+XRPTransaction.swift
@@ -10,15 +10,18 @@ internal extension XRPTransaction {
   /// - Parameters:
   ///     - transaction: an Org_Xrpl_Rpc_V1_Transaction (protobuf object) whose field values will be used to
   ///                 construct an XRPTransaction
+  ///     - xrplNetwork: The XRPL network from which this object was retrieved, defaults to XRPLNetwork.main (Mainnet).
   /// - Returns: an XRPTransaction with its fields set via the analogous protobuf fields.
-  init?(getTransactionResponse: Org_Xrpl_Rpc_V1_GetTransactionResponse, xrplNetwork: XRPLNetwork) {
+  init?(getTransactionResponse: Org_Xrpl_Rpc_V1_GetTransactionResponse, xrplNetwork: XRPLNetwork = XRPLNetwork.main) {
 
     let transaction: Org_Xrpl_Rpc_V1_Transaction = getTransactionResponse.transaction
 
     let hashBytes = [UInt8](getTransactionResponse.hash)
     self.hash = hashBytes.toHex()
     self.account = transaction.account.value.address
-    self.accountXAddress = Utils.encode(classicAddress: self.account, tag: nil, isTest: xrplNetwork == XRPLNetwork.test)!
+    self.accountXAddress = Utils.encode(classicAddress: self.account,
+                                        tag: nil,
+                                        isTest: xrplNetwork == XRPLNetwork.test)!
     self.fee = transaction.fee.drops
     self.sequence = transaction.sequence.value
     self.signingPublicKey = transaction.signingPublicKey.value

--- a/XpringKit/XRP/model/Org_Xrpl_Rpc_V1_Transaction+XRPTransaction.swift
+++ b/XpringKit/XRP/model/Org_Xrpl_Rpc_V1_Transaction+XRPTransaction.swift
@@ -11,13 +11,14 @@ internal extension XRPTransaction {
   ///     - transaction: an Org_Xrpl_Rpc_V1_Transaction (protobuf object) whose field values will be used to
   ///                 construct an XRPTransaction
   /// - Returns: an XRPTransaction with its fields set via the analogous protobuf fields.
-  init?(getTransactionResponse: Org_Xrpl_Rpc_V1_GetTransactionResponse) {
+  init?(getTransactionResponse: Org_Xrpl_Rpc_V1_GetTransactionResponse, xrplNetwork: XRPLNetwork) {
 
     let transaction: Org_Xrpl_Rpc_V1_Transaction = getTransactionResponse.transaction
 
     let hashBytes = [UInt8](getTransactionResponse.hash)
     self.hash = hashBytes.toHex()
     self.account = transaction.account.value.address
+    self.accountXAddress = Utils.encode(classicAddress: self.account, tag: nil, isTest: xrplNetwork == XRPLNetwork.test)!
     self.fee = transaction.fee.drops
     self.sequence = transaction.sequence.value
     self.signingPublicKey = transaction.signingPublicKey.value
@@ -32,7 +33,7 @@ internal extension XRPTransaction {
 
     switch transaction.transactionData {
     case .payment(let payment):
-      guard let paymentFields = XRPPayment(payment: payment) else {
+      guard let paymentFields = XRPPayment(payment: payment, xrplNetwork: xrplNetwork) else {
         return nil
       }
       self.paymentFields = paymentFields

--- a/XpringKit/XRP/model/XRPPayment.swift
+++ b/XpringKit/XRP/model/XRPPayment.swift
@@ -16,7 +16,7 @@ public struct XRPPayment: Equatable {
 
   /// The address and (optional) destination tag of the account receiving the payment, encoded in X-address format.
   /// - SeeAlso: https://xrpaddress.info
-  public let destinationXAddress: Address
+  public let destinationXAddress: Address?
 
   /// (Optional) Minimum amount of destination currency this transaction should deliver.
   public let deliverMin: XRPCurrencyAmount?

--- a/XpringKit/XRP/model/XRPPayment.swift
+++ b/XpringKit/XRP/model/XRPPayment.swift
@@ -14,6 +14,10 @@ public struct XRPPayment: Equatable {
   /// (Optional) Arbitrary tag that identifies a hosted recipient to pay, or the reason for the payment.
   public let destinationTag: UInt32?
 
+  /// The address and (optional) destination tag of the account receiving the payment, encoded in X-address format.
+  /// - SeeAlso: https://xrpaddress.info
+  public let destinationXAddress: Address
+  
   /// (Optional) Minimum amount of destination currency this transaction should deliver.
   public let deliverMin: XRPCurrencyAmount?
 

--- a/XpringKit/XRP/model/XRPPayment.swift
+++ b/XpringKit/XRP/model/XRPPayment.swift
@@ -17,7 +17,7 @@ public struct XRPPayment: Equatable {
   /// The address and (optional) destination tag of the account receiving the payment, encoded in X-address format.
   /// - SeeAlso: https://xrpaddress.info
   public let destinationXAddress: Address
-  
+
   /// (Optional) Minimum amount of destination currency this transaction should deliver.
   public let deliverMin: XRPCurrencyAmount?
 

--- a/XpringKit/XRP/model/XRPTransaction.swift
+++ b/XpringKit/XRP/model/XRPTransaction.swift
@@ -15,7 +15,7 @@ public struct XRPTransaction: Equatable {
 
   /// The unique address of the account that initiated the transaction, encoded in X-address format.
   /// - SeeAlso: https://xrpaddress.info
-  public let accountXAddress: Address
+  public let accountXAddress: Address?
 
   /// (Optional) Hash value identifying another transaction. If provided, this transaction is only valid if
   /// the sending account's previously-sent transaction matches the provided hash.

--- a/XpringKit/XRP/model/XRPTransaction.swift
+++ b/XpringKit/XRP/model/XRPTransaction.swift
@@ -13,6 +13,10 @@ public struct XRPTransaction: Equatable {
   /// The unique address of the account that initiated the transaction.
   public let account: Address
 
+  /// The unique address of the account that initiated the transaction, encoded in X-address format.
+  /// - SeeAlso: https://xrpaddress.info
+  public let accountXAddress: Address
+  
   /// (Optional) Hash value identifying another transaction. If provided, this transaction is only valid if
   /// the sending account's previously-sent transaction matches the provided hash.
   public let accountTransactionID: Data?

--- a/XpringKit/XRP/model/XRPTransaction.swift
+++ b/XpringKit/XRP/model/XRPTransaction.swift
@@ -16,7 +16,7 @@ public struct XRPTransaction: Equatable {
   /// The unique address of the account that initiated the transaction, encoded in X-address format.
   /// - SeeAlso: https://xrpaddress.info
   public let accountXAddress: Address
-  
+
   /// (Optional) Hash value identifying another transaction. If provided, this transaction is only valid if
   /// the sending account's previously-sent transaction matches the provided hash.
   public let accountTransactionID: Data?


### PR DESCRIPTION
## High Level Overview of Change
This PR adds X-address to the `XRPPayment` and `XRPTransaction` model objects.  `XRPPayment` contains a `destination` and a `destinationTag` property, and now also contains a `destinationXAddress` property that is the X-address encoded version of this information. `XRPTransaction` contains an `account` property, and now also contains an `accountXAddress` property, which is the X-address encoded version of the originating account with no destination tag.

In order to create the correct X-address encoding, we need to know whether we're on Testnet or Mainnet.  Therefore the constructors for `XRPPayment` and `XRPTransaction` now have an additional `xrplNetwork: XRPLNetwork` parameter.  Tests and client code have been updated accordingly (including addition of this network param to the `XRPClientDecorator` and implementors, since this needs to be plumbed through in order to construct accurate `XRPTransaction`s)

Analogue in JS: https://github.com/xpring-eng/Xpring-JS/pull/487
Analogue in Java: https://github.com/xpring-eng/xpring4j/pull/250
<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] New feature (non-breaking change which adds functionality)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After
`XRPTransaction` and `XRPPayment` now contain X-address versions of address and tag properties. 
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
Unit tests for protocol buffer conversion into these objects have been updated to verify the X-address properties.
CI still passes.
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->


## Future Tasks
<!--
For future tasks related to PR.
-->
Questions for @keefertaylor 
- do we need to deprecate the classic address/tag fields, or just leave everything side-by-side?
- should a note about this go in the CHANGELOG?  The `XRPTransaction` and `XRPPayment` objects have an additional constructor parameter, but it's optional (defaults to Mainnet) and thus isn't a breaking change.
- should other classes that contain XRP addresses (such as `XRPPathElement` or `XRPIssuedCurrency`) also contain X-address versions of these?