### PR TITLE
Provide a synchronous API for PayIDClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `XRPPayment` and `XRPTransaction` now contain X-address representations of their address and tag fields.
   (See https://xrpaddress.info/)
-- A new method on `PayIDClient`, `address(for:)`, provides a synchronous implementation of `address(for:completion:)`. 
+- A new method on `PayIDClient`, `address(for:)`, provides a synchronous implementation of `address(for:completion:)`.
+- A new parameter, `callbackQueue`, in `PayIDClient`'s `address(for:callbackQueue:completion:)` allows callers to specify the queue to run the callback on.  
 	
 ### Deprecated
 - `XRPTransaction.account` and `XRPTransaction.sourceTag` are deprecated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `XRPPayment` and `XRPTransaction` now contain X-address representations of their address and tag fields.
   (See https://xrpaddress.info/)
+- A new method on `PayIDClient`, `address(for:)`, provides a synchronous implementation of `address(for:completion:)`. 
 	
 ### Deprecated
 - `XRPTransaction.account` and `XRPTransaction.sourceTag` are deprecated.

--- a/Tests/Helpers/DispatchQueue+Test.swift
+++ b/Tests/Helpers/DispatchQueue+Test.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Extensions to DispatchQueue for testing.
+/// - SeeAlso: https://stackoverflow.com/questions/17475002/get-current-dispatch-queue/60314121#60314121
+extension DispatchQueue {
+
+  static func registerDetection(of queue: DispatchQueue) {
+    _registerDetection(of: [queue], key: key)
+  }
+
+  static var currentQueueLabel: String? { current?.label }
+  static var current: DispatchQueue? { getSpecific(key: key)?.queue }
+
+  private struct QueueReference { weak var queue: DispatchQueue? }
+
+  private static let key: DispatchSpecificKey<QueueReference> = {
+    let key = DispatchSpecificKey<QueueReference>()
+    setupSystemQueuesDetection(key: key)
+    return key
+  }()
+
+  private static func _registerDetection(of queues: [DispatchQueue], key: DispatchSpecificKey<QueueReference>) {
+    queues.forEach { $0.setSpecific(key: key, value: QueueReference(queue: $0)) }
+  }
+
+  private static func setupSystemQueuesDetection(key: DispatchSpecificKey<QueueReference>) {
+    let queues: [DispatchQueue] = [
+      .main,
+      .global(qos: .background),
+      .global(qos: .default),
+      .global(qos: .unspecified),
+      .global(qos: .userInitiated),
+      .global(qos: .userInteractive),
+      .global(qos: .utility)
+    ]
+    _registerDetection(of: queues, key: key)
+  }
+}

--- a/Tests/PayID/PayIDIntegrationTests.swift
+++ b/Tests/PayID/PayIDIntegrationTests.swift
@@ -10,27 +10,29 @@ extension PaymentPointer {
 
 /// Integration tests run against a live PayID service.
 final class PayIDIntegrationTests: XCTestCase {
-  func testResolvePaymentPointerKnownPointerMainnet() {
-    let expectation = XCTestExpectation(description: "resolveToXRP completion called.")
-
-    // GIVEN a Pay ID that will resolve on Mainnet and a PayID client.
-    let payIDClient = XRPPayIDClient(xrplNetwork: .main)
-
-    // WHEN it is resolved to an XRP address.
-    payIDClient.xrpAddress(for: .testPointer) { result in
-      // THEN the address is the expected value.
-      switch result {
-      case .success(let resolvedAddress):
-        XCTAssertEqual(resolvedAddress, "X7zmKiqEhMznSXgj9cirEnD5sWo3iZSbeFRexSFN1xZ8Ktn")
-      case .failure(let error):
-        XCTFail("Failed to resolve address: \(error)")
-      }
-
-      expectation.fulfill()
-    }
-
-    self.wait(for: [ expectation ], timeout: 10)
-  }
+//  func testResolvePaymentPointerKnownPointerMainnet() {
+//    let expectation = XCTestExpectation(description: "resolveToXRP completion called.")
+//
+//    // GIVEN a Pay ID that will resolve on Mainnet and a PayID client.
+//    let payIDClient = XRPPayIDClient(xrplNetwork: .main)
+//
+//    // WHEN it is resolved to an XRP address.
+//    let result = payIDClient.xrpAddress(for: .testPointer)
+//
+//
+//      // THEN the address is the expected value.
+//      switch result {
+//      case .success(let resolvedAddress):
+//        XCTAssertEqual(resolvedAddress, "X7zmKiqEhMznSXgj9cirEnD5sWo3iZSbeFRexSFN1xZ8Ktn")
+//      case .failure(let error):
+//        XCTFail("Failed to resolve address: \(error)")
+//      }
+//
+////      expectation.fulfill()
+////    }
+//
+////    self.wait(for: [ expectation ], timeout: 10)
+//  }
 
   func testResolvePaymentPointerKnownPointerTestnet() {
     let expectation = XCTestExpectation(description: "resolveToXRP completion called.")
@@ -80,12 +82,12 @@ final class PayIDIntegrationTests: XCTestCase {
   }
 
   func testResolveKnownPayIDToBTCTestNet() {
-    let expectation = XCTestExpectation(description: "resolveToBTC completion called.")
+//    let expectation = XCTestExpectation(description: "resolveToBTC completion called.")
 
     // GIVEN a Pay ID that will resolve on Mainnet.
     // WHEN it is resolved to an XRP address
     let payIDClient = PayIDClient(network: "btc-testnet")
-    payIDClient.address(for: .testPointer) { result in
+    let result = try! payIDClient.address(for: .testPointer)// { result in
       // THEN the address is the expected value.
       switch result {
       case .success(let resolvedAddress):
@@ -93,8 +95,8 @@ final class PayIDIntegrationTests: XCTestCase {
       case .failure(let error):
         XCTFail("Failed to resolve address: \(error)")
       }
-      expectation.fulfill()
-    }
-    self.wait(for: [ expectation ], timeout: 10)
+//      expectation.fulfill()
+//    }
+//    self.wait(for: [ expectation ], timeout: 10)
   }
 }

--- a/Tests/PayID/PayIDIntegrationTests.swift
+++ b/Tests/PayID/PayIDIntegrationTests.swift
@@ -17,7 +17,7 @@ final class PayIDIntegrationTests: XCTestCase {
     let payIDClient = XRPPayIDClient(xrplNetwork: .main)
 
     // WHEN it is resolved to an XRP address.
-    let result = payIDClient.xrpAddress(for: .testPointer) { result in
+    payIDClient.xrpAddress(for: .testPointer) { result in
       // THEN the address is the expected value.
       switch result {
       case .success(let resolvedAddress):
@@ -85,13 +85,12 @@ final class PayIDIntegrationTests: XCTestCase {
     let payIDClient = PayIDClient(network: "btc-testnet")
     let result = try! payIDClient.address(for: .testPointer)
 
-
-      // THEN the address is the expected value.
-      switch result {
-      case .success(let resolvedAddress):
-        XCTAssertEqual(resolvedAddress.address, "2NF9H32iwQcVcoAiiBmAtjpGmQfsmU5L6SR")
-      case .failure(let error):
-        XCTFail("Failed to resolve address: \(error)")
-      }
+    // THEN the address is the expected value.
+    switch result {
+    case .success(let resolvedAddress):
+      XCTAssertEqual(resolvedAddress.address, "2NF9H32iwQcVcoAiiBmAtjpGmQfsmU5L6SR")
+    case .failure(let error):
+      XCTFail("Failed to resolve address: \(error)")
+    }
   }
 }

--- a/Tests/PayID/PayIDIntegrationTests.swift
+++ b/Tests/PayID/PayIDIntegrationTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import XpringKit
 
@@ -32,18 +33,20 @@ final class PayIDIntegrationTests: XCTestCase {
     self.wait(for: [ expectation ], timeout: 10)
   }
 
-  // TODO(keefertaylor): This should really be a unit test. Migrate when
+  // TODO(keefertaylor): This should  be a unit test. Migrate when
   // https://github.com/xpring-eng/XpringKit/pull/238 is landed.
   func testResolvePaymentPointerKnownPointerMainnetOnCustomThread() {
     let expectation = XCTestExpectation(description: "resolveToXRP completion called.")
 
     // GIVEN a Pay ID that will resolve on Mainnet and a PayID client and a custom callback queue.
-    let customCallbackQueue = DispatchQueue(label: "io.xpring.XpringKit.test")
+    let queueLabel = "io.xpring.XpringKit.test"
+    let customCallbackQueue = DispatchQueue(label: queueLabel)
+    DispatchQueue.registerDetection(of: customCallbackQueue)
     let payIDClient = PayIDClient(network: "xrpl-main")
 
     // WHEN it is resolved to an XRP address and provided a custom queue and not on the main thread.
     payIDClient.address(for: .testPointer, callbackQueue: customCallbackQueue) { _ in
-      XCTAssertFalse(Thread.isMainThread)
+      XCTAssertEqual(DispatchQueue.currentQueueLabel, queueLabel)
       expectation.fulfill()
     }
 

--- a/Tests/PayID/PayIDIntegrationTests.swift
+++ b/Tests/PayID/PayIDIntegrationTests.swift
@@ -32,6 +32,24 @@ final class PayIDIntegrationTests: XCTestCase {
     self.wait(for: [ expectation ], timeout: 10)
   }
 
+  // TODO(keefertaylor): This should really be a unit test. Migrate when
+  // https://github.com/xpring-eng/XpringKit/pull/238 is landed.
+  func testResolvePaymentPointerKnownPointerMainnetOnCustomThread() {
+    let expectation = XCTestExpectation(description: "resolveToXRP completion called.")
+
+    // GIVEN a Pay ID that will resolve on Mainnet and a PayID client and a custom callback queue.
+    let customCallbackQueue = DispatchQueue(label: "io.xpring.XpringKit.test")
+    let payIDClient = PayIDClient(network: "xrpl-main")
+
+    // WHEN it is resolved to an XRP address and provided a custom queue and not on the main thread.
+    payIDClient.address(for: .testPointer, callbackQueue: customCallbackQueue) { _ in
+      XCTAssertFalse(Thread.isMainThread)
+      expectation.fulfill()
+    }
+
+    self.wait(for: [ expectation ], timeout: 10)
+  }
+
   func testResolvePaymentPointerKnownPointerTestnet() {
     let expectation = XCTestExpectation(description: "resolveToXRP completion called.")
 

--- a/Tests/PayID/PayIDIntegrationTests.swift
+++ b/Tests/PayID/PayIDIntegrationTests.swift
@@ -10,29 +10,27 @@ extension PaymentPointer {
 
 /// Integration tests run against a live PayID service.
 final class PayIDIntegrationTests: XCTestCase {
-//  func testResolvePaymentPointerKnownPointerMainnet() {
-//    let expectation = XCTestExpectation(description: "resolveToXRP completion called.")
-//
-//    // GIVEN a Pay ID that will resolve on Mainnet and a PayID client.
-//    let payIDClient = XRPPayIDClient(xrplNetwork: .main)
-//
-//    // WHEN it is resolved to an XRP address.
-//    let result = payIDClient.xrpAddress(for: .testPointer)
-//
-//
-//      // THEN the address is the expected value.
-//      switch result {
-//      case .success(let resolvedAddress):
-//        XCTAssertEqual(resolvedAddress, "X7zmKiqEhMznSXgj9cirEnD5sWo3iZSbeFRexSFN1xZ8Ktn")
-//      case .failure(let error):
-//        XCTFail("Failed to resolve address: \(error)")
-//      }
-//
-////      expectation.fulfill()
-////    }
-//
-////    self.wait(for: [ expectation ], timeout: 10)
-//  }
+  func testResolvePaymentPointerKnownPointerMainnet() {
+    let expectation = XCTestExpectation(description: "resolveToXRP completion called.")
+
+    // GIVEN a Pay ID that will resolve on Mainnet and a PayID client.
+    let payIDClient = XRPPayIDClient(xrplNetwork: .main)
+
+    // WHEN it is resolved to an XRP address.
+    let result = payIDClient.xrpAddress(for: .testPointer) { result in
+      // THEN the address is the expected value.
+      switch result {
+      case .success(let resolvedAddress):
+        XCTAssertEqual(resolvedAddress, "X7zmKiqEhMznSXgj9cirEnD5sWo3iZSbeFRexSFN1xZ8Ktn")
+      case .failure(let error):
+        XCTFail("Failed to resolve address: \(error)")
+      }
+
+      expectation.fulfill()
+    }
+
+    self.wait(for: [ expectation ], timeout: 10)
+  }
 
   func testResolvePaymentPointerKnownPointerTestnet() {
     let expectation = XCTestExpectation(description: "resolveToXRP completion called.")
@@ -82,12 +80,12 @@ final class PayIDIntegrationTests: XCTestCase {
   }
 
   func testResolveKnownPayIDToBTCTestNet() {
-//    let expectation = XCTestExpectation(description: "resolveToBTC completion called.")
-
     // GIVEN a Pay ID that will resolve on Mainnet.
     // WHEN it is resolved to an XRP address
     let payIDClient = PayIDClient(network: "btc-testnet")
-    let result = try! payIDClient.address(for: .testPointer)// { result in
+    let result = try! payIDClient.address(for: .testPointer)
+
+
       // THEN the address is the expected value.
       switch result {
       case .success(let resolvedAddress):
@@ -95,8 +93,5 @@ final class PayIDIntegrationTests: XCTestCase {
       case .failure(let error):
         XCTFail("Failed to resolve address: \(error)")
       }
-//      expectation.fulfill()
-//    }
-//    self.wait(for: [ expectation ], timeout: 10)
   }
 }

--- a/XpringKit.xcodeproj/project.pbxproj
+++ b/XpringKit.xcodeproj/project.pbxproj
@@ -226,10 +226,12 @@
 		8879C0212B57361BF52414EB /* XRPPathElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09110E77523CEAC3EBEDE72 /* XRPPathElement.swift */; };
 		8963BAFECA3AF44F048F120D /* XRPPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0B9773B47C926571988CFD /* XRPPath.swift */; };
 		897EA2C4E392FFEB2472CB4B /* FakeIlpBalanceNetworkClient+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1C7A870F6A536D32F84C5A /* FakeIlpBalanceNetworkClient+Test.swift */; };
+		8A3F97E6C0D715A56C2274AE /* DispatchQueue+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A7D03FD0E94B4BE488D492F /* DispatchQueue+Test.swift */; };
 		8AE4A6FEF0F045BF21E24CD6 /* send_payment_request.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E23041846F93763A0728711 /* send_payment_request.pb.swift */; };
 		8B1E27C492144A138ACD1E1D /* Org_Xrpl_Rpc_V1_GetTransactionResponse+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F77CCF884CC7677A66315EB /* Org_Xrpl_Rpc_V1_GetTransactionResponse+Test.swift */; };
 		8D18C4538BFC9A307CD4659E /* BigInt.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3E837E32019F19EDE7F76CC /* BigInt.framework */; };
 		8DA13B8F6244BD0BB4332F67 /* ilp_over_http_service.grpc.swift in Sources */ = {isa = PBXBuildFile; fileRef = D648D6DF94C4AD7D2D62DD23 /* ilp_over_http_service.grpc.swift */; };
+		8DE66EB249EAAE687931CE6B /* DispatchQueue+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A7D03FD0E94B4BE488D492F /* DispatchQueue+Test.swift */; };
 		8E3C7BE2B811D856D602C3FA /* XRPPayIDClientProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8654761B791845DE0FECFA7 /* XRPPayIDClientProtocol.swift */; };
 		8E6248A3C8EB5F0FA3B419EF /* JavaScriptWallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 936154C6013FA34EBED32C27 /* JavaScriptWallet.swift */; };
 		905D00AE6A8DB3FB353C53E6 /* XRPPath+Org_Xrpl_Rpc_V1_Payment.Path.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B61CE4F8FD13B71A6D0A8B6 /* XRPPath+Org_Xrpl_Rpc_V1_Payment.Path.swift */; };
@@ -488,6 +490,7 @@
 		18077DF3636B89329378E9AB /* PaymentRequest+Org_Interledger_Stream_Proto_SendPaymentRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentRequest+Org_Interledger_Stream_Proto_SendPaymentRequest.swift"; sourceTree = "<group>"; };
 		18DA771894252F05403656DC /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIService.swift; sourceTree = "<group>"; };
 		1A39FB2D5EF0857FA0E2A6F5 /* JavaScriptWalletGenerationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JavaScriptWalletGenerationResult.swift; sourceTree = "<group>"; };
+		1A7D03FD0E94B4BE488D492F /* DispatchQueue+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+Test.swift"; sourceTree = "<group>"; };
 		1C2DA5A1A6E86CF2533F12F8 /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
 		1D8206BB243AA0E447DE94EA /* JavaScriptSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JavaScriptSerializer.swift; sourceTree = "<group>"; };
 		1DB2A63111797F370978DD13 /* WalletGenerationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletGenerationResult.swift; sourceTree = "<group>"; };
@@ -739,6 +742,7 @@
 				17F0F394ABBB673AF8D4048B /* AccountID+Test.swift */,
 				B26D12954276D34124999E61 /* Address+Test.swift */,
 				69CCAD7A1BD799F748A87B19 /* Data+Test.swift */,
+				1A7D03FD0E94B4BE488D492F /* DispatchQueue+Test.swift */,
 				0A1C7A870F6A536D32F84C5A /* FakeIlpBalanceNetworkClient+Test.swift */,
 				A45AABC76DA29DC3CD2AD93B /* FakeIlpPaymentNetworkClient+Test.swift */,
 				0EAE29A6751A2516A04A4A8D /* FakeNetworkClient+Test.swift */,
@@ -1517,6 +1521,7 @@
 				26E489E7A27EDB433E16B895 /* Data+Test.swift in Sources */,
 				FF18DBC0AE89D5006391BD80 /* DefaultIlpClientTest.swift in Sources */,
 				3B2A80AB60DDE58CFAA4ADF0 /* DefaultXRPClientTest.swift in Sources */,
+				8A3F97E6C0D715A56C2274AE /* DispatchQueue+Test.swift in Sources */,
 				897EA2C4E392FFEB2472CB4B /* FakeIlpBalanceNetworkClient+Test.swift in Sources */,
 				ED34AFD6EF2C92BBD3DA6E34 /* FakeIlpBalanceNetworkClient.swift in Sources */,
 				6FC72342159BD52E6B1F6335 /* FakeIlpPaymentNetworkClient+Test.swift in Sources */,
@@ -1574,6 +1579,7 @@
 				E663928F98A181B892F5EC73 /* Data+Test.swift in Sources */,
 				98D797AF3A336A5D3E60F6CA /* DefaultIlpClientTest.swift in Sources */,
 				AF4DADF31EC574BAB6AC804B /* DefaultXRPClientTest.swift in Sources */,
+				8DE66EB249EAAE687931CE6B /* DispatchQueue+Test.swift in Sources */,
 				695E8A111BA6231E19B000D0 /* FakeIlpBalanceNetworkClient+Test.swift in Sources */,
 				59460E25FF4672CD92F4E6A3 /* FakeIlpBalanceNetworkClient.swift in Sources */,
 				10DB7A6148E30B7A06B30F33 /* FakeIlpPaymentNetworkClient+Test.swift in Sources */,

--- a/XpringKit/PayID/PayIDClient.swift
+++ b/XpringKit/PayID/PayIDClient.swift
@@ -33,7 +33,7 @@ public class PayIDClient {
   ///   - ach
   ///
   //  TODO: Link a canonical list at payid.org when available.
-  public init(network: String, completionQueue: DispatchQueue = DispatchQueue.main) {
+  public init(network: String) {
     self.network = network
   }
 

--- a/XpringKit/PayID/PayIDClient.swift
+++ b/XpringKit/PayID/PayIDClient.swift
@@ -74,8 +74,10 @@ public class PayIDClient {
     completion: @escaping (Result<CryptoAddressDetails, PayIDError>) -> Void
   ) {
     // Wrap completion calls in a closure which will dispatch to the callback queue.
-    let queueSafeCompletion: (Result<CryptoAddressDetails, PayIDError>) -> Void = {
-      completion($0)
+    let queueSafeCompletion: (Result<CryptoAddressDetails, PayIDError>) -> Void = { result in
+      callbackQueue.async {
+        completion(result)
+      }
     }
 
     guard let payIDComponents = PayIDUtils.parse(payID: payID) else {


### PR DESCRIPTION
## High Level Overview of Change

Add threading logic for `PayIDClient`.

### Context of Change

This change:
- Runs all networking on a dedicated queue
- Allows users to specify a callback queue (defaults to the main queue, which is the same behavior as before)
- Provides a synchronous method to fetch PayIDs
- Updates a test to prove the synchronous method works. 

This is largely motivated by it being [hard to write demo code](https://github.com/xpring-eng/Xpring-SDK-Demo/pull/39) but likely just makes developer's lives easier overall.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

New APIs introduced to make working with PayID easier.

## Test Plan

CI 

## Future Tasks
We'll need to do something similar in `XRPPayIDClient` and `XpringClient`. 