### PR TITLE
Fix Destination Tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Payments sent to a destination tag would drop their tag. This release contains a fix for this issue.
+
 ## 3.2.1 - 2020-06-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- Payments sent to a destination tag would drop their tag. This release contains a fix for this issue.
+- Destination tags were being dropped from payments. This release fixes the issue.
 
 ## 3.2.1 - 2020-06-16
 

--- a/Tests/XRP/XRPClientIntegrationTests.swift
+++ b/Tests/XRP/XRPClientIntegrationTests.swift
@@ -31,6 +31,23 @@ final class XRPClientIntegrationTests: XCTestCase {
     }
   }
 
+  func testSendXRPWithDestinationTag() {
+    // GIVEN a transaction hash representing a payment with a destination tag.
+    let tag: UInt32 = 123
+    let address = "rPEPPER7kfTD9w2To4CQk6UCfuHM9c6GDY"
+    let taggedXAddress = Utils.encode(classicAddress: address, tag: tag, isTest: true)!
+    let transactionHash = try! client.send(.testSendAmount, to: taggedXAddress, from: .testWallet)
+
+    // WHEN the payment is retrieved
+    let transaction = try! client.getPayment(for: transactionHash)
+
+    // THEN the payment has the correct destination.
+    let destinationXAddress = transaction?.paymentFields?.destinationXAddress
+    let destinationAddressComponents = Utils.decode(xAddress: destinationXAddress!)!
+    XCTAssertEqual(destinationAddressComponents.classicAddress, address)
+    XCTAssertEqual(destinationAddressComponents.tag, tag)
+  }
+
   func testPaymentStatus() {
     do {
       let transactionHash = try client.send(.testSendAmount, to: .recipientAddress, from: .testWallet)

--- a/XpringKit/XRP/DefaultXRPClient.swift
+++ b/XpringKit/XRP/DefaultXRPClient.swift
@@ -132,7 +132,7 @@ extension DefaultXRPClient: XRPClientDecorator {
     var payment = Org_Xrpl_Rpc_V1_Payment.with {
       $0.destination = Org_Xrpl_Rpc_V1_Destination.with {
         $0.value = Org_Xrpl_Rpc_V1_AccountAddress.with {
-          $0.address = destinationClassicAddressComponents.classicAddress
+          $0.address = destinationAddress
         }
       }
 
@@ -142,11 +142,6 @@ extension DefaultXRPClient: XRPClientDecorator {
             $0.drops = amount
           }
         }
-      }
-    }
-    if let destinationTag = destinationClassicAddressComponents.tag {
-      payment.destinationTag = Org_Xrpl_Rpc_V1_DestinationTag.with {
-        $0.value = destinationTag
       }
     }
 


### PR DESCRIPTION
## High Level Overview of Change

Fix an issue where XpringKit drops destination tags on sends. 

Addresses issue https://github.com/xpring-eng/xpring4j/issues/264.

### Context of Change

Our serialization library expects destination addresses to be in X-Address format and xpring4j was providing classic address / tag combinations. 

The serialization library shouldn't mess this up. That change is in https://github.com/xpring-eng/xpring-common-js/pull/346. 

This change fixes the immediate issue by passing through X-Addresses. Add an integration test to prove this works as expected. 

We will do a release ASAP after this change is merged. 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Fixes a bug. 

## Test Plan

CI. New tests are provided. 
