### PR TITLE
(3/17) Creates `XRPCheckCancel` Protobuf Wrapper Class

### DIFF
--- a/Tests/XRP/Helpers/Data+Test.swift
+++ b/Tests/XRP/Helpers/Data+Test.swift
@@ -6,4 +6,5 @@ extension Data {
   public static let testHash = Data([2, 4, 6])
   public static let testEmailHashValue = Data([8, 9, 10])
   public static let testMessageKeyValue = Data([11, 12, 13])
+  public static let testCheckIdValue = Data(base64Encoded: "49647F0D748DC3FE26BDACBC57F251AADEFFF391403EC9BF87C97F67E9977FB0")!
 }

--- a/Tests/XRP/Helpers/Data+Test.swift
+++ b/Tests/XRP/Helpers/Data+Test.swift
@@ -6,5 +6,7 @@ extension Data {
   public static let testHash = Data([2, 4, 6])
   public static let testEmailHashValue = Data([8, 9, 10])
   public static let testMessageKeyValue = Data([11, 12, 13])
-  public static let testCheckIdValue = Data(base64Encoded: "49647F0D748DC3FE26BDACBC57F251AADEFFF391403EC9BF87C97F67E9977FB0")!
+  public static let testCheckIdValue = "49647F0D748DC3FE26BDACBC57F251AADEFFF391403EC9BF87C97F67E9977FB0".data(
+    using: .utf8
+  )!
 }

--- a/Tests/XRP/Helpers/TransactionTypeTestProtos/Org_Xrpl_Rpc_V1_CheckCancel+Test.swift
+++ b/Tests/XRP/Helpers/TransactionTypeTestProtos/Org_Xrpl_Rpc_V1_CheckCancel+Test.swift
@@ -1,0 +1,11 @@
+import XpringKit
+
+extension Org_Xrpl_Rpc_V1_CheckCancel {
+  public static let testCheckCancelAllFields = Org_Xrpl_Rpc_V1_CheckCancel.with {
+    $0.checkID = Org_Xrpl_Rpc_V1_CheckID.with {
+      $0.value = .testCheckIdValue!
+    }
+  }
+
+  public static let testCheckCancelMissingCheckId = Org_Xrpl_Rpc_V1_CheckCancel()
+}

--- a/Tests/XRP/Helpers/TransactionTypeTestProtos/Org_Xrpl_Rpc_V1_CheckCancel+Test.swift
+++ b/Tests/XRP/Helpers/TransactionTypeTestProtos/Org_Xrpl_Rpc_V1_CheckCancel+Test.swift
@@ -3,7 +3,7 @@ import XpringKit
 extension Org_Xrpl_Rpc_V1_CheckCancel {
   public static let testCheckCancelAllFields = Org_Xrpl_Rpc_V1_CheckCancel.with {
     $0.checkID = Org_Xrpl_Rpc_V1_CheckID.with {
-      $0.value = .testCheckIdValue!
+      $0.value = .testCheckIdValue
     }
   }
 

--- a/Tests/XRP/TransactionTypeProtobufConversionTest.swift
+++ b/Tests/XRP/TransactionTypeProtobufConversionTest.swift
@@ -84,4 +84,31 @@ final class TransactionTypeProtobufConversionTests: XCTestCase {
     // THEN the result is nil.
     XCTAssertNil(xrpAccountDelete)
   }
+
+  // MARK: - Org_Xrpl_Rpc_V1_CheckCancel
+
+  func testConvertCheckCancelAllFields() {
+    // GIVEN a CheckCancel protocol buffer.
+    let checkCancel = Org_Xrpl_Rpc_V1_CheckCancel.testCheckCancelAllFields
+
+    // WHEN the protocol buffer is converted to a native Swift type.
+    let xrpCheckCancel = XRPCheckCancel(checkCancel: checkCancel)
+
+    // THEN the CheckCancel converted as expected.
+    XCTAssertEqual(
+      xrpCheckCancel?.checkId,
+      String(data: checkCancel.checkID.value, encoding: .utf8)
+    )
+  }
+
+  func testConvertCheckCancelMissingCheckId() {
+    // GIVEN a CheckCancel protocol buffer without a checkId.
+    let checkCancel = Org_Xrpl_Rpc_V1_CheckCancel.testCheckCancelMissingCheckId
+
+    // WHEN the protocol buffer is converted to a native Swift type.
+    let xrpCheckCancel = XRPCheckCancel(checkCancel: checkCancel)
+
+    // THEN the result is nil.
+    XCTAssertNil(xrpCheckCancel)
+  }
 }

--- a/XpringKit.xcodeproj/project.pbxproj
+++ b/XpringKit.xcodeproj/project.pbxproj
@@ -209,6 +209,7 @@
 		709AE5B1DE61918ED6C9941D /* FakeWallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D03D284E7D4E73A4C78B0F /* FakeWallet.swift */; };
 		70BE5B82126D5A772D7846D5 /* WalletTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE441EC25D8B42CD3E4F7569 /* WalletTest.swift */; };
 		721C6014D60596D20A58F3B8 /* FakeIlpBalanceNetworkClient+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = C170C17611E46F0F02508840 /* FakeIlpBalanceNetworkClient+Test.swift */; };
+		72287422ADA9C124C6B8B6E0 /* Org_Xrpl_Rpc_V1_CheckCancel+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591F7A665EE579CCA071CCDB /* Org_Xrpl_Rpc_V1_CheckCancel+Test.swift */; };
 		7291259F246E10B85B4C6B0B /* JavaScriptWallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 936154C6013FA34EBED32C27 /* JavaScriptWallet.swift */; };
 		736E434DE9BDE30D0F801D05 /* CgRPC.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CC8297246A38A843C88376EC /* CgRPC.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		73E582E9F2D1AA9DBEB34CD5 /* XRPPathElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09110E77523CEAC3EBEDE72 /* XRPPathElement.swift */; };
@@ -418,6 +419,7 @@
 		EE377A658C50664ECC0AB863 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F86C0A2876CAF3304B8960 /* APIClient.swift */; };
 		EF4566B752ABFA56E75A18CF /* BigInt.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EA714A0B484B0B0CB6D39B77 /* BigInt.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		EFCB119388225280AABFD96E /* XRPPathElement+Org_Xrpl_Rpc_V1_Payment.PathElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0739B8545F537741E2221EF4 /* XRPPathElement+Org_Xrpl_Rpc_V1_Payment.PathElement.swift */; };
+		F059E44B2BA11049A0C67F48 /* Org_Xrpl_Rpc_V1_CheckCancel+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591F7A665EE579CCA071CCDB /* Org_Xrpl_Rpc_V1_CheckCancel+Test.swift */; };
 		F07E925E8555752497C97FAC /* TransactionHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E9424A41D18492198557AE1 /* TransactionHash.swift */; };
 		F26849C0411336A3B42816FD /* XRPAccountDelete+Org_Xrpl_Rpc_V1_AccountDelete.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C8D93C2E9C4C73FB73E213 /* XRPAccountDelete+Org_Xrpl_Rpc_V1_AccountDelete.swift */; };
 		F2F99F745A88C8AF29BEDF98 /* IlpClientDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56259EB063F354CA78095B0A /* IlpClientDecorator.swift */; };
@@ -577,6 +579,7 @@
 		5829FCE75C14EBAED939613E /* XRPTransactionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XRPTransactionType.swift; sourceTree = "<group>"; };
 		5876E70A990EAE71B4FCC69A /* UInt64+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UInt64+Test.swift"; sourceTree = "<group>"; };
 		58A74192BD297BC4E78F9B95 /* SwiftGRPC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SwiftGRPC.framework; sourceTree = "<group>"; };
+		591F7A665EE579CCA071CCDB /* Org_Xrpl_Rpc_V1_CheckCancel+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Org_Xrpl_Rpc_V1_CheckCancel+Test.swift"; sourceTree = "<group>"; };
 		59841301C850376F77AA7470 /* Org_Interledger_Stream_Proto_GetBalanceResponse+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Org_Interledger_Stream_Proto_GetBalanceResponse+Test.swift"; sourceTree = "<group>"; };
 		5B2BA278976D9647A3DB2DB0 /* Wallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Wallet.swift; sourceTree = "<group>"; };
 		5B61CE4F8FD13B71A6D0A8B6 /* XRPPath+Org_Xrpl_Rpc_V1_Payment.Path.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XRPPath+Org_Xrpl_Rpc_V1_Payment.Path.swift"; sourceTree = "<group>"; };
@@ -1161,6 +1164,7 @@
 			children = (
 				5258C6AB2F1552C7D9CF93B8 /* Org_Xrpl_Rpc_V1_AccountDelete+Test.swift */,
 				F314E4015173B942F5CF7DCD /* Org_Xrpl_Rpc_V1_AccountSet+Test.swift */,
+				591F7A665EE579CCA071CCDB /* Org_Xrpl_Rpc_V1_CheckCancel+Test.swift */,
 			);
 			path = TransactionTypeTestProtos;
 			sourceTree = "<group>";
@@ -1682,6 +1686,7 @@
 				FEE4682CC59B57CB514CBE5B /* Org_Interledger_Stream_Proto_SendPaymentResponse+Test.swift in Sources */,
 				836A796C5422D9389A434D88 /* Org_Xrpl_Rpc_V1_AccountDelete+Test.swift in Sources */,
 				AD61D5A4A6C82AB4AC194AD0 /* Org_Xrpl_Rpc_V1_AccountSet+Test.swift in Sources */,
+				72287422ADA9C124C6B8B6E0 /* Org_Xrpl_Rpc_V1_CheckCancel+Test.swift in Sources */,
 				801073442732409311803CF7 /* Org_Xrpl_Rpc_V1_GetAccountTransactionHistoryResponse+Test.swift in Sources */,
 				BE0808BE5B0DDCCE9FF6A41E /* Org_Xrpl_Rpc_V1_GetTransactionResponse+Test.swift in Sources */,
 				3406B54D7FDE828ACD48AC24 /* Org_Xrpl_Rpc_V1_Transaction+Test.swift in Sources */,
@@ -1747,6 +1752,7 @@
 				03CF0E5F10D2D4C4E69A09E3 /* Org_Interledger_Stream_Proto_SendPaymentResponse+Test.swift in Sources */,
 				B99DEB164875938D868BD61E /* Org_Xrpl_Rpc_V1_AccountDelete+Test.swift in Sources */,
 				191F12178457A2318A18CE7F /* Org_Xrpl_Rpc_V1_AccountSet+Test.swift in Sources */,
+				F059E44B2BA11049A0C67F48 /* Org_Xrpl_Rpc_V1_CheckCancel+Test.swift in Sources */,
 				2AF9EAB5DA6E0392EE46D1A7 /* Org_Xrpl_Rpc_V1_GetAccountTransactionHistoryResponse+Test.swift in Sources */,
 				F3FCB85078C703F1105CE565 /* Org_Xrpl_Rpc_V1_GetTransactionResponse+Test.swift in Sources */,
 				522AD19F46DE57E9F9C94E9F /* Org_Xrpl_Rpc_V1_Transaction+Test.swift in Sources */,

--- a/XpringKit.xcodeproj/project.pbxproj
+++ b/XpringKit.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		18A146781880FE4B92B84F85 /* RawTransactionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7670AFE8249A612BEC6D796 /* RawTransactionStatus.swift */; };
 		18CA1A1E15B8B6A8DCB27B31 /* IlpIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3EC418C7EDE883220EF480 /* IlpIntegrationTests.swift */; };
 		191F12178457A2318A18CE7F /* Org_Xrpl_Rpc_V1_AccountSet+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = F314E4015173B942F5CF7DCD /* Org_Xrpl_Rpc_V1_AccountSet+Test.swift */; };
+		19926D0D458B54C22E220818 /* XRPCheckCancel+Org_Xrpl_Rpc_V1_CheckCancel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D0B419D9778090A72495A7 /* XRPCheckCancel+Org_Xrpl_Rpc_V1_CheckCancel.swift */; };
 		1B0ADD62A8FBE0725DE8B416 /* Hex+ByteArrayTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FCCFA28F807A915F5646D51 /* Hex+ByteArrayTest.swift */; };
 		1B7B34F4ECD11BC1D2E9D663 /* TransactionArray+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4765147301E513DEECF27B /* TransactionArray+Test.swift */; };
 		1BA018D2C59D52A341F0FAAE /* index.js in Resources */ = {isa = PBXBuildFile; fileRef = 1E87C4427452AFF47BAF7DED /* index.js */; };
@@ -127,6 +128,7 @@
 		4601617786A1377A786D1AE5 /* xrp_ledger.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FAB75935C39AABBC836E688 /* xrp_ledger.pb.swift */; };
 		4614500A9D49C811FF75CCF4 /* JavaScriptSigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8EEC64CCAD52CFE23E34F4C /* JavaScriptSigner.swift */; };
 		46722EC1C4D2AC45060CF679 /* DefaultIlpClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA56A942C3C3BC82B5291917 /* DefaultIlpClient.swift */; };
+		469AD634DDF25F096917332C /* XRPCheckCancel+Org_Xrpl_Rpc_V1_CheckCancel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D0B419D9778090A72495A7 /* XRPCheckCancel+Org_Xrpl_Rpc_V1_CheckCancel.swift */; };
 		46CA9260022235C9D77E5914 /* Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349C93E752A7CFAA25714770 /* Address.swift */; };
 		47296BBCA407603357853E0C /* account_service.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2DF0640E820C026DB952C18 /* account_service.pb.swift */; };
 		4751B385C955CEFD0252138E /* XRPAccountSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C4999525E7F38DFF75DB00F /* XRPAccountSet.swift */; };
@@ -152,6 +154,7 @@
 		5365902D371988D14E73B23F /* account.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 131CA8117639B2887A575A67 /* account.pb.swift */; };
 		53690B5D039D8CA6427509A4 /* Coding.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC6589215B2EC43F32C69BE7 /* Coding.swift */; };
 		538AA7F5099B2B5CE4739EB0 /* PostPathReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2319CC6D8250A36AB245A1C0 /* PostPathReceipt.swift */; };
+		540D0B6C01D7B1A444B0AD06 /* XRPCheckCancel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E89FF91DA6C89412580BA2 /* XRPCheckCancel.swift */; };
 		541CC256A1199B3D67EFD654 /* XRPPayment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735068C7A64DC6AF7A54259E /* XRPPayment.swift */; };
 		5434D43A21EB37A996FC78F5 /* FakeIlpBalanceNetworkClient+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = C170C17611E46F0F02508840 /* FakeIlpBalanceNetworkClient+Test.swift */; };
 		544A914D6DAAC55D1C361449 /* XRPMemo+Org_Xrpl_Rpc_V1_Memo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89D8E6D4E974184B0F1B3E85 /* XRPMemo+Org_Xrpl_Rpc_V1_Memo.swift */; };
@@ -361,7 +364,6 @@
 		CBBE7AECF7E18424E6D58AFE /* XpringClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 161B7F046E7CC2194DC644CE /* XpringClient.swift */; };
 		CC5516528B98F9E393B5CF61 /* Int32+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2913330E34F42EC17B8FB6AE /* Int32+Test.swift */; };
 		CD116E62344EE02F42721786 /* Receipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0B42EBEA6F84C15A44CC2CE /* Receipt.swift */; };
-		CDF50AA224EAF386000B8E88 /* XRPCheckCancel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF50AA124EAF386000B8E88 /* XRPCheckCancel.swift */; };
 		CF1D7CB1E7128069E5934CB6 /* XRPCurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E60E57E0D6A0FF8BBFC144 /* XRPCurrency.swift */; };
 		CF95FA9CC3755257969EDEB6 /* Originator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FDA0EE747FA302E6B5B06 /* Originator.swift */; };
 		D077E7518B53EDF7B123AA89 /* Beneficiary.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6B2C88E146F5BCB6B89AAD5 /* Beneficiary.swift */; };
@@ -401,6 +403,7 @@
 		E2861E7E00B68F6B5A05EEE5 /* Int32+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2913330E34F42EC17B8FB6AE /* Int32+Test.swift */; };
 		E2A51C9AC1B4A3EC1E23ECDA /* XRPMemo+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C45AA95C09A0B88961589D4 /* XRPMemo+Test.swift */; };
 		E42583EC5FDE6CEC679920DC /* PaymentResult+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76CFB08E7F3C0EECF55DB9A5 /* PaymentResult+Test.swift */; };
+		E58FEB15F043C1AABA41CABD /* XRPCheckCancel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E89FF91DA6C89412580BA2 /* XRPCheckCancel.swift */; };
 		E5FD4CA665D77D461D26D753 /* PaymentResult+Org_Interledger_Stream_Proto_PaymentResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C2B63E6C36B965673870445 /* PaymentResult+Org_Interledger_Stream_Proto_PaymentResult.swift */; };
 		E649E4D27D0A0438F8F5D9AF /* IlpClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212C92E14DA12887A571FAB4 /* IlpClient.swift */; };
 		E6ADACCEA1F59031262798E5 /* Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3DD7F7849850E454579FAB /* Hex.swift */; };
@@ -619,6 +622,7 @@
 		933AF7A4BA1668CCAFFD6BAE /* FakeIlpPaymentNetworkClient+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FakeIlpPaymentNetworkClient+Test.swift"; sourceTree = "<group>"; };
 		936154C6013FA34EBED32C27 /* JavaScriptWallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JavaScriptWallet.swift; sourceTree = "<group>"; };
 		93D359F32A772F877A173DDB /* XRPLNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XRPLNetwork.swift; sourceTree = "<group>"; };
+		96D0B419D9778090A72495A7 /* XRPCheckCancel+Org_Xrpl_Rpc_V1_CheckCancel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XRPCheckCancel+Org_Xrpl_Rpc_V1_CheckCancel.swift"; sourceTree = "<group>"; };
 		986BDA26F8AB37729FD65EE1 /* FakeIlpPaymentNetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeIlpPaymentNetworkClient.swift; sourceTree = "<group>"; };
 		9BBCEC49991A2A3F4CF51170 /* Value.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Value.swift; sourceTree = "<group>"; };
 		9F45E1DF43583AFB9E57EC7E /* XRPClientIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XRPClientIntegrationTests.swift; sourceTree = "<group>"; };
@@ -659,13 +663,13 @@
 		C40259FA3F9F9E9680E535A1 /* ReliableSubmissionXRPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReliableSubmissionXRPClient.swift; sourceTree = "<group>"; };
 		C4CE107831B8C2BFCBD0D23B /* AccountID+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccountID+Test.swift"; sourceTree = "<group>"; };
 		C51BDD3392187F741AE12052 /* TransactionHash+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TransactionHash+Test.swift"; sourceTree = "<group>"; };
+		C7E89FF91DA6C89412580BA2 /* XRPCheckCancel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XRPCheckCancel.swift; sourceTree = "<group>"; };
 		C96BB00E8F8A1000EF3B59F1 /* IlpNetworkPaymentClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IlpNetworkPaymentClient.swift; sourceTree = "<group>"; };
 		CA56A942C3C3BC82B5291917 /* DefaultIlpClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultIlpClient.swift; sourceTree = "<group>"; };
 		CB022AF22A0CFE65BE15CD66 /* meta.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = meta.pb.swift; sourceTree = "<group>"; };
 		CB2D27DE0D1F7A7A038E0B68 /* ledger_objects.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ledger_objects.pb.swift; sourceTree = "<group>"; };
 		CC1E4BD45BB559AE45D49D46 /* PaymentInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentInformation.swift; sourceTree = "<group>"; };
 		CC8297246A38A843C88376EC /* CgRPC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CgRPC.framework; sourceTree = "<group>"; };
-		CDF50AA124EAF386000B8E88 /* XRPCheckCancel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XRPCheckCancel.swift; sourceTree = "<group>"; };
 		CE441EC25D8B42CD3E4F7569 /* WalletTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletTest.swift; sourceTree = "<group>"; };
 		CE62519308284A0B43B03823 /* Wallet+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Wallet+Test.swift"; sourceTree = "<group>"; };
 		D2A44415073DF3370D66A1C4 /* XRPCurrencyAmount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XRPCurrencyAmount.swift; sourceTree = "<group>"; };
@@ -1085,6 +1089,8 @@
 				72C8D93C2E9C4C73FB73E213 /* XRPAccountDelete+Org_Xrpl_Rpc_V1_AccountDelete.swift */,
 				7C4999525E7F38DFF75DB00F /* XRPAccountSet.swift */,
 				1DCD2F4DD6196A994F0B6AAB /* XRPAccountSet+Org_Xrpl_Rpc_V1_AccountSet.swift */,
+				C7E89FF91DA6C89412580BA2 /* XRPCheckCancel.swift */,
+				96D0B419D9778090A72495A7 /* XRPCheckCancel+Org_Xrpl_Rpc_V1_CheckCancel.swift */,
 				C1E60E57E0D6A0FF8BBFC144 /* XRPCurrency.swift */,
 				DF59AC0A2C8F4E921D00E796 /* XRPCurrency+Org_Xrpl_Rpc_V1_CurrencyAmount.swift */,
 				D2A44415073DF3370D66A1C4 /* XRPCurrencyAmount.swift */,
@@ -1104,7 +1110,6 @@
 				B39FA8ECF7B07FB0EC70FA7B /* XRPTransaction.swift */,
 				873AD6590979FDB99E3F6E51 /* XRPTransaction+Org_Xrpl_Rpc_V1_Transaction.swift */,
 				5829FCE75C14EBAED939613E /* XRPTransactionType.swift */,
-				CDF50AA124EAF386000B8E88 /* XRPCheckCancel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1398,6 +1403,8 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1020;
+				TargetAttributes = {
+				};
 			};
 			buildConfigurationList = C0A52FC1F46AB2CDA8428A29 /* Build configuration list for PBXProject "XpringKit" */;
 			compatibilityVersion = "Xcode 10.0";
@@ -1583,6 +1590,8 @@
 				03D2C7234CFADD6F1AC18D5F /* XRPAccountDelete.swift in Sources */,
 				62D231E1C293D190C751C638 /* XRPAccountSet+Org_Xrpl_Rpc_V1_AccountSet.swift in Sources */,
 				44117512B896274F43C0A904 /* XRPAccountSet.swift in Sources */,
+				469AD634DDF25F096917332C /* XRPCheckCancel+Org_Xrpl_Rpc_V1_CheckCancel.swift in Sources */,
+				E58FEB15F043C1AABA41CABD /* XRPCheckCancel.swift in Sources */,
 				55A865A1BF7C94359CC85F71 /* XRPClient.swift in Sources */,
 				38BCFD93B3EC15CD520F4466 /* XRPClientDecorator.swift in Sources */,
 				26EE88020DB1F32AB536BD19 /* XRPClientProtocol.swift in Sources */,
@@ -1759,7 +1768,6 @@
 				2F976D2D086DD42DD212EAE9 /* TransactionTypeProtobufConversionTest.swift in Sources */,
 				4BF8E7531D8AFCE23B1E9A2F /* UInt32+Test.swift in Sources */,
 				EC58D2DF20B19E0BD31FF1DC /* UInt64+Test.swift in Sources */,
-				CDF50AA224EAF386000B8E88 /* XRPCheckCancel.swift in Sources */,
 				68B01D0D3E788749C87B9BF2 /* UtilsTest.swift in Sources */,
 				438DD11C1CDAFA9A6A0B75BB /* Wallet+Test.swift in Sources */,
 				C3EE52BF557A3771073EC3BD /* WalletTest.swift in Sources */,
@@ -1862,6 +1870,8 @@
 				6A6D7174968E7C07461F355F /* XRPAccountDelete.swift in Sources */,
 				F521DF53D1DF00641E71323B /* XRPAccountSet+Org_Xrpl_Rpc_V1_AccountSet.swift in Sources */,
 				4751B385C955CEFD0252138E /* XRPAccountSet.swift in Sources */,
+				19926D0D458B54C22E220818 /* XRPCheckCancel+Org_Xrpl_Rpc_V1_CheckCancel.swift in Sources */,
+				540D0B6C01D7B1A444B0AD06 /* XRPCheckCancel.swift in Sources */,
 				0FEA27C970EE6D5EF7120EA9 /* XRPClient.swift in Sources */,
 				168A866A039B6438107A7ACC /* XRPClientDecorator.swift in Sources */,
 				0B2882C0DD355BCBEA3E07AF /* XRPClientProtocol.swift in Sources */,
@@ -2008,12 +2018,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-					"@loader_path/../Frameworks",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks $(PROJECT_DIR)/Carthage/Build/iOS";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -2206,12 +2211,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-					"@loader_path/../Frameworks",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks $(PROJECT_DIR)/Carthage/Build/iOS";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;

--- a/XpringKit.xcodeproj/project.pbxproj
+++ b/XpringKit.xcodeproj/project.pbxproj
@@ -361,6 +361,7 @@
 		CBBE7AECF7E18424E6D58AFE /* XpringClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 161B7F046E7CC2194DC644CE /* XpringClient.swift */; };
 		CC5516528B98F9E393B5CF61 /* Int32+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2913330E34F42EC17B8FB6AE /* Int32+Test.swift */; };
 		CD116E62344EE02F42721786 /* Receipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0B42EBEA6F84C15A44CC2CE /* Receipt.swift */; };
+		CDF50AA224EAF386000B8E88 /* XRPCheckCancel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF50AA124EAF386000B8E88 /* XRPCheckCancel.swift */; };
 		CF1D7CB1E7128069E5934CB6 /* XRPCurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E60E57E0D6A0FF8BBFC144 /* XRPCurrency.swift */; };
 		CF95FA9CC3755257969EDEB6 /* Originator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FDA0EE747FA302E6B5B06 /* Originator.swift */; };
 		D077E7518B53EDF7B123AA89 /* Beneficiary.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6B2C88E146F5BCB6B89AAD5 /* Beneficiary.swift */; };
@@ -664,6 +665,7 @@
 		CB2D27DE0D1F7A7A038E0B68 /* ledger_objects.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ledger_objects.pb.swift; sourceTree = "<group>"; };
 		CC1E4BD45BB559AE45D49D46 /* PaymentInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentInformation.swift; sourceTree = "<group>"; };
 		CC8297246A38A843C88376EC /* CgRPC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CgRPC.framework; sourceTree = "<group>"; };
+		CDF50AA124EAF386000B8E88 /* XRPCheckCancel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XRPCheckCancel.swift; sourceTree = "<group>"; };
 		CE441EC25D8B42CD3E4F7569 /* WalletTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletTest.swift; sourceTree = "<group>"; };
 		CE62519308284A0B43B03823 /* Wallet+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Wallet+Test.swift"; sourceTree = "<group>"; };
 		D2A44415073DF3370D66A1C4 /* XRPCurrencyAmount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XRPCurrencyAmount.swift; sourceTree = "<group>"; };
@@ -1102,6 +1104,7 @@
 				B39FA8ECF7B07FB0EC70FA7B /* XRPTransaction.swift */,
 				873AD6590979FDB99E3F6E51 /* XRPTransaction+Org_Xrpl_Rpc_V1_Transaction.swift */,
 				5829FCE75C14EBAED939613E /* XRPTransactionType.swift */,
+				CDF50AA124EAF386000B8E88 /* XRPCheckCancel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1395,8 +1398,6 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1020;
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = C0A52FC1F46AB2CDA8428A29 /* Build configuration list for PBXProject "XpringKit" */;
 			compatibilityVersion = "Xcode 10.0";
@@ -1758,6 +1759,7 @@
 				2F976D2D086DD42DD212EAE9 /* TransactionTypeProtobufConversionTest.swift in Sources */,
 				4BF8E7531D8AFCE23B1E9A2F /* UInt32+Test.swift in Sources */,
 				EC58D2DF20B19E0BD31FF1DC /* UInt64+Test.swift in Sources */,
+				CDF50AA224EAF386000B8E88 /* XRPCheckCancel.swift in Sources */,
 				68B01D0D3E788749C87B9BF2 /* UtilsTest.swift in Sources */,
 				438DD11C1CDAFA9A6A0B75BB /* Wallet+Test.swift in Sources */,
 				C3EE52BF557A3771073EC3BD /* WalletTest.swift in Sources */,
@@ -2006,7 +2008,12 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks $(PROJECT_DIR)/Carthage/Build/iOS";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -2199,7 +2206,12 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks $(PROJECT_DIR)/Carthage/Build/iOS";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;

--- a/XpringKit/XRP/Model/XRPCheckCancel+Org_Xrpl_Rpc_V1_CheckCancel.swift
+++ b/XpringKit/XRP/Model/XRPCheckCancel+Org_Xrpl_Rpc_V1_CheckCancel.swift
@@ -15,5 +15,8 @@ internal extension XRPCheckCancel {
   /// - Returns: an XRPCheckCancel with its fields set via the analogous protobuf fields.
   init?(checkCancel: Org_Xrpl_Rpc_V1_CheckCancel) {
     self.checkId = String(decoding: checkCancel.checkID.value, as: UTF8.self)
+    if self.checkId.isEmpty {
+      return nil
+    }
   }
 }

--- a/XpringKit/XRP/Model/XRPCheckCancel+Org_Xrpl_Rpc_V1_CheckCancel.swift
+++ b/XpringKit/XRP/Model/XRPCheckCancel+Org_Xrpl_Rpc_V1_CheckCancel.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Conforms to XRPCheckCancel struct while providing an initializer that can construct an XRPCheckCancel
+/// from an Org_Xrpl_Rpc_V1_CheckCancel
+internal extension XRPCheckCancel {
+
+  /// Constructs an XRPCheckCancel from an Org_Xrpl_Rpc_V1_CheckCancel
+  /// - SeeAlso: [CheckCancel Protocol Buffer]
+  /// (https://github.com/ripple/rippled/blob/3d86b49dae8173344b39deb75e53170a9b6c5284/
+  /// src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L126)
+  ///
+  /// - Parameters:
+  ///     - checkCancel: an Org_Xrpl_Rpc_V1_CheckCancel (protobuf object) whose field values will be used to
+  ///             construct an XRPCheckCancel
+  /// - Returns: an XRPCheckCancel with its fields set via the analogous protobuf fields.
+  init?(checkCancel: Org_Xrpl_Rpc_V1_CheckCancel) {
+    self.checkId = String(decoding: checkCancel.checkID.value, as: UTF8.self)
+  }
+}

--- a/XpringKit/XRP/Model/XRPCheckCancel.swift
+++ b/XpringKit/XRP/Model/XRPCheckCancel.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Represents a CheckCancel transaction on the XRP Ledger.
+///
+/// A CheckCancel transaction cancels an unredeemed Check, removing it from the ledger without sending any money.
+/// The source or the destination of the check can cancel a Check at any time using this transaction type.
+/// If the Check has expired, any address can cancel it.
+///
+/// - SeeAlso: https://xrpl.org/checkcancel.html
+public struct XRPCheckCancel: Equatable {
+
+  /// The ID of the Check ledger object to cancel, as a 64-character hexadecimal string.
+  public let checkId: String
+}

--- a/XpringKit/XRP/Model/XRPTransactionType.swift
+++ b/XpringKit/XRP/Model/XRPTransactionType.swift
@@ -5,4 +5,7 @@
 /// - SeeAlso: https://xrpl.org/transaction-formats.html
 public enum XRPTransactionType {
   case payment
+  case accountSet
+  case accountDelete
+  case checkCancel
 }


### PR DESCRIPTION
## High Level Overview of Change
This PR implements the class `XRPCheckCancel` - a native Swift class to wrap the [`CheckCancel` protocol buffer](https://github.com/ripple/rippled/blob/3d86b49dae8173344b39deb75e53170a9b6c5284/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L126).  See also: https://xrpl.org/checkcancel.html
<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
Effort to implement additional [XRPL transaction types](https://xrpl.org/transaction-types.html) beyond `Payment` in the SDK.
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] New feature (non-breaking change which adds functionality)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After
`XRPCheckCancel` class and conversion unit tests now exist.
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
Unit tests added to verify conversion.  CI passes.
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

## Future Tasks
<!--
For future tasks related to PR.
-->